### PR TITLE
fix: restore tier CI and fully judge pinned core

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,60 @@
 # Handoff
 
+Updated: 2026-08-14 (pinned core corpus fully judged and delivered)
+
+## Pinned core conformance residue eliminated
+
+- Continued `codex/fix-ci-skips` from fetched `origin/main@12c1a4c`; no merge
+  was needed because that remote head is already an ancestor. Toolchain is FPC
+  3.2.2 through lwpt 0.5.1 only.
+- The runner now provides the pinned standard `spectest` module: all seven
+  print functions, immutable numeric globals, i32/i64 tables, and memory. Its
+  store objects are allocated once per script and shared across modules. A
+  later script `(register "spectest" ...)` replaces the built-in as one whole
+  module; imports never splice exports from both.
+- `assert_unlinkable` now resolves and instantiates through the shipped path and
+  passes only on a prefix-matching `EWasmLinkError`. Named module definitions
+  retain validated model/IR/bytes; module instances are fresh and generative.
+  The corpus's elided-wrapper inline module body is assembled as one module.
+- The final 10 binary diagnostic mismatches are fixed at the grammar boundary:
+  signed s7 composite discriminators, physical LEB width checks across declared
+  body spans, missing-END versus code-section size classification, and the
+  confirmed export-name list overrun. Valid function bodies retain the single
+  fused validation walk; malformed-only probing is gated.
+- Spec evidence was checked at `spec/main@d7b37e4170d8315f2f1283aed4e8076591a9a333`
+  (`binary-int`, `binary-code`, `binary-section`, `binary-comptype`,
+  `binary-name`, `binary-list`, `exec-module`, `exec-instantiation`) and the
+  standard host against the pinned reference `spectest.ml`.
+
+## Final local evidence
+
+- `git diff --check`, `lwpt format --check`, `lwpt install --frozen`, and
+  `lwpt build`: green.
+- `lwpt test`: 44/44 suites, 1,224 tests, no compile/test failures.
+- Markdown lint: 41 files, 0 issues.
+- Pinned core, 257 scripts, identical in every tier:
+  `pass=65188 fail=0 skip=0 staged=0`; JIT/AOT `compiled=8703`.
+- Recursive 288-script mirror, identical in every tier:
+  `pass=65851 fail=368 skip=904 staged=0`; JIT/AOT `compiled=8799`.
+  The residue is explicitly outside core 3.0: 14 legacy EH failures; 354
+  post-3.0 proposal failures; 20 testsuite-local custom skips; and 884
+  downstream `no instantiated module` skips in legacy/proposals. There are
+  zero unresolved-import or `assert_unlinkable` skips.
+- Independent integration reviews found two edge risks (registered `spectest`
+  precedence and an over-broad export-boundary diagnostic); both were fixed
+  with counter-tests before the final gate.
+
+## Delivery
+
+- Implementation commit: `8dba9c1` (`fix: fully judge the pinned core corpus`).
+- Current-truth documentation commit: `e2bea80`
+  (`docs: record complete core conformance`).
+- Full six-platform CI run `31754666992` passed at exact source/docs head
+  `e2bea80`: aarch64/x86-64 macOS, aarch64/x86-64 Linux, and i386/x86-64
+  Windows. The branch is pushed as `origin/codex/fix-ci-skips`.
+- This handoff-only closure commit follows that tested source/docs head; no
+  implementation or generated state changed after the exact-head run.
+
 Updated: 2026-08-13 (main CI repair and corpus-residue audit)
 
 ## Main CI repair

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -46,6 +46,10 @@ Updated: 2026-08-14 (pinned core corpus fully judged and delivered)
 
 ## Delivery
 
+- Draft PR [#2](https://github.com/frostney/wasmlight/pull/2),
+  `fix: restore tier CI and fully judge pinned core`, is open against `main`.
+  Keep it draft until the PR-triggered checks pass on the exact final head, then
+  mark it ready for review.
 - Implementation commit: `8dba9c1` (`fix: fully judge the pinned core corpus`).
 - Current-truth documentation commit: `e2bea80`
   (`docs: record complete core conformance`).

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,41 @@
 # Handoff
 
+Updated: 2026-08-13 (main CI repair and corpus-residue audit)
+
+## Main CI repair
+
+- Synced from fetched `origin/main` at `12c1a4c` and created
+  `codex/fix-ci-skips`.
+- Main run `31645850311` failed only on native x86_64-darwin: the interpreter
+  passed `call.wast:337`, while JIT/AOT surfaced FPC `EStackOverflow` during
+  deep direct compiled recursion instead of trapping `call stack exhausted`.
+- The direct-call fast path consumes native stack per non-tail call. The shared
+  logical cap of 8192 frames was too generous for the Intel macOS process
+  stack, so all tiers now share a conservative 1024-frame cap. This is an
+  implementation resource limit allowed by pinned-spec anchor `impl-exec` and
+  keeps tier exhaustion identical rather than adding a Darwin-only carve-out.
+- CI now retains each tier's `--failures-only` output and prints a focused diff
+  on tally divergence. Diagnostic run `31673377733` proved the exact failing
+  assertion; the other five platform legs were green.
+- Local gates after the cap change: frozen install, format check, all three
+  builds, 44/44 unit suites, and full interpreter/JIT/AOT corpus identity at
+  `65204 pass / 389 fail / 1532 skip / 0 errors` (compiled=8588).
+
+## Remaining corpus residue audit
+
+- Root suite: 33 fail / 610 skip. Proposals: 356 fail / 922 skip.
+- Root failures are 10 decode-message/framing mismatches, 5 module-definition /
+  instance commands, 16 legacy EH assertions (explicitly out of the 3.0
+  target), and 2 other module-definition uses in memory/table coverage.
+- Root skips are 96 missing `spectest` imports, 291 cascaded commands after
+  those modules do not instantiate, 200 `assert_unlinkable` commands the
+  harness still does not judge, and 23 non-reference custom directives.
+- The actionable next conformance wave is harness plumbing, not runtime opcode
+  work: provide the standard `spectest` funcs/globals/table/table64/memory,
+  then judge `assert_unlinkable` through the existing instantiator/link errors.
+  That can retire most root skips. Keep proposal residue and legacy EH outside
+  the pinned core-3.0 claim.
+
 Updated: 2026-08-12 (fifth measured optimization wave integrated and
 cross-architecture/cross-tier validated; PR #1 open)
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -11,7 +11,8 @@ Updated: 2026-08-13 (main CI repair and corpus-residue audit)
   deep direct compiled recursion instead of trapping `call stack exhausted`.
 - The direct-call fast path consumes native stack per non-tail call. The shared
   logical cap of 8192 frames was too generous for the Intel macOS process
-  stack, so all tiers now share a conservative 1024-frame cap. This is an
+  stack. A 1024-frame cap still overflowed on the heavier indirect-call path,
+  so all tiers now share a conservative 256-frame cap. This is an
   implementation resource limit allowed by pinned-spec anchor `impl-exec` and
   keeps tier exhaustion identical rather than adding a Darwin-only carve-out.
 - CI now retains each tier's `--failures-only` output and prints a focused diff
@@ -25,8 +26,8 @@ Updated: 2026-08-13 (main CI repair and corpus-residue audit)
 
 - Root suite: 33 fail / 610 skip. Proposals: 356 fail / 922 skip.
 - Root failures are 10 decode-message/framing mismatches, 5 module-definition /
-  instance commands, 16 legacy EH assertions (explicitly out of the 3.0
-  target), and 2 other module-definition uses in memory/table coverage.
+  instance commands, 14 legacy EH assertions (explicitly out of the 3.0
+  target), and 4 other module-definition uses in memory/table coverage.
 - Root skips are 96 missing `spectest` imports, 291 cascaded commands after
   those modules do not instantiate, 200 `assert_unlinkable` commands the
   harness still does not judge, and 23 non-reference custom directives.
@@ -373,7 +374,7 @@ cross-architecture/cross-tier validated; PR #1 open)
   classify correctly (+4, wired through interp AND both JIT backends AND
   the const-expr evaluator so all tiers stay identical); addrtype text
   forms / anyfunc / id.wast lexer / ref.func-declared-set / throw wording
-  (+8). Remaining 389 = 356 post-3.0 proposals + 16 legacy EH (both out
+  (+8). Remaining 389 = 356 post-3.0 proposals + 14 legacy EH (both out
   of scope) + ~9 (module definition/instance) harness forms + a few
   deferred decode/framing edges.
 - **Superseded perf note (measurement was contaminated):** aarch64-darwin,

--- a/.agent/design/interp-spec.md
+++ b/.agent/design/interp-spec.md
@@ -95,12 +95,14 @@ end;
 
 Both caps are tunables (constants in `Wasm.Interp`, overridable for tests):
 `WASM_INTERP_VALUE_SLOTS` (default `1 shl 20` = 1 Mi slots = 8 MiB reserved)
-and `WASM_INTERP_MAX_DEPTH` (default `8192`). A push that would exceed
+and `WASM_INTERP_MAX_DEPTH` (default `1024`). A push that would exceed
 EITHER cap is `TrapNow(wtkStackExhausted)` (§5.2) — this is how a
 non-recursive interpreter honours `assert_exhaustion`. Sizing note: 1 Mi
 slots is comfortably above any non-pathological program and the exhaustion
-tests trip the depth cap first; both are deliberately generous and both are
-observable only as the `call stack exhausted` trap.
+tests trip the depth cap first. The frame cap also leaves headroom for a
+compiled non-tail call's native frame on supported hosts; every tier uses this
+same logical cap, so exhaustion remains observationally identical. Both caps
+are observable only as the `call stack exhausted` trap.
 
 Why fixed reservations rather than a growable value stack: a growable
 `array of TWasmValue` reallocates on growth, which moves every live frame's

--- a/.agent/design/interp-spec.md
+++ b/.agent/design/interp-spec.md
@@ -95,7 +95,7 @@ end;
 
 Both caps are tunables (constants in `Wasm.Interp`, overridable for tests):
 `WASM_INTERP_VALUE_SLOTS` (default `1 shl 20` = 1 Mi slots = 8 MiB reserved)
-and `WASM_INTERP_MAX_DEPTH` (default `1024`). A push that would exceed
+and `WASM_INTERP_MAX_DEPTH` (default `256`). A push that would exceed
 EITHER cap is `TrapNow(wtkStackExhausted)` (§5.2) — this is how a
 non-recursive interpreter honours `assert_exhaustion`. Sizing note: 1 Mi
 slots is comfortably above any non-pathological program and the exhaustion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,13 +205,14 @@ jobs:
           WS=./build/wasmspec${{ matrix.exe }}
           FLOOR=64000
           run_tier() {
-            local output total
+            local output_file total
+            output_file="$RUNNER_TEMP/wasmspec-$1.txt"
             set +e
-            output=$("$WS" --failures-only --tier="$1" tests/spec/testsuite)
+            "$WS" --failures-only --tier="$1" tests/spec/testsuite > "$output_file"
             set -e
-            total=$(printf '%s\n' "$output" | grep '^TOTAL' || true)
+            total=$(grep '^TOTAL' "$output_file" || true)
             if [ -z "$total" ]; then
-              printf '%s\n' "$output" >&2
+              cat "$output_file" >&2
               echo "::error::$1 did not produce a TOTAL tally" >&2
               return 1
             fi
@@ -228,7 +229,15 @@ jobs:
             AL=$(run_tier aot); echo "aot:    $AL"
             [ "$(field "$JL" errors)" = "0" ] || { echo "::error::jit errors!=0"; exit 1; }
             [ "$(field "$AL" errors)" = "0" ] || { echo "::error::aot errors!=0"; exit 1; }
-            [ "$(sig "$JL")" = "$IS" ] || { echo "::error::jit tally diverges from interpreter"; exit 1; }
-            [ "$(sig "$AL")" = "$IS" ] || { echo "::error::aot tally diverges from interpreter"; exit 1; }
+            if [ "$(sig "$JL")" != "$IS" ]; then
+              echo "::error::jit tally diverges from interpreter"
+              diff -u "$RUNNER_TEMP/wasmspec-interp.txt" "$RUNNER_TEMP/wasmspec-jit.txt" || true
+              exit 1
+            fi
+            if [ "$(sig "$AL")" != "$IS" ]; then
+              echo "::error::aot tally diverges from interpreter"
+              diff -u "$RUNNER_TEMP/wasmspec-interp.txt" "$RUNNER_TEMP/wasmspec-aot.txt" || true
+              exit 1
+            fi
             echo "three-tier identity OK"
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,13 +191,14 @@ jobs:
           WS=./build/wasmspec${{ matrix.exe }}
           FLOOR=64000
           run_tier() {
-            local output total
+            local output_file total
+            output_file="$RUNNER_TEMP/wasmspec-$1.txt"
             set +e
-            output=$("$WS" --failures-only --tier="$1" tests/spec/testsuite)
+            "$WS" --failures-only --tier="$1" tests/spec/testsuite > "$output_file"
             set -e
-            total=$(printf '%s\n' "$output" | grep '^TOTAL' || true)
+            total=$(grep '^TOTAL' "$output_file" || true)
             if [ -z "$total" ]; then
-              printf '%s\n' "$output" >&2
+              cat "$output_file" >&2
               echo "::error::$1 did not produce a TOTAL tally" >&2
               return 1
             fi
@@ -214,8 +215,16 @@ jobs:
             AL=$(run_tier aot); echo "aot:    $AL"
             [ "$(field "$JL" errors)" = "0" ] || { echo "::error::jit errors!=0"; exit 1; }
             [ "$(field "$AL" errors)" = "0" ] || { echo "::error::aot errors!=0"; exit 1; }
-            [ "$(sig "$JL")" = "$IS" ] || { echo "::error::jit tally diverges from interpreter"; exit 1; }
-            [ "$(sig "$AL")" = "$IS" ] || { echo "::error::aot tally diverges from interpreter"; exit 1; }
+            if [ "$(sig "$JL")" != "$IS" ]; then
+              echo "::error::jit tally diverges from interpreter"
+              diff -u "$RUNNER_TEMP/wasmspec-interp.txt" "$RUNNER_TEMP/wasmspec-jit.txt" || true
+              exit 1
+            fi
+            if [ "$(sig "$AL")" != "$IS" ]; then
+              echo "::error::aot tally diverges from interpreter"
+              diff -u "$RUNNER_TEMP/wasmspec-interp.txt" "$RUNNER_TEMP/wasmspec-aot.txt" || true
+              exit 1
+            fi
             echo "three-tier identity OK"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ canonical vocabulary before planning anything.
   which trap fires and when — is a bug, not a tier characteristic. All
   three tiers are shipped, and this is **enforced in CI**: `wasmspec
   --tier=interp|jit|aot` over the pinned corpus must produce a
-  byte-identical tally (65,204 pass on both aarch64 and x86-64), and the
+  byte-identical pinned-core tally (65,188 pass, 0 fail, 0 skip), and the
   JIT/AOT legs assert that identity against the interpreter. The JIT and
   AOT are a 64-bit-UNIX acceleration (`WASM_JIT_EXEC`, backends
   `Wasm.Jit.Arm64` / `Wasm.Jit.X64`); on Windows and 32-bit targets the
@@ -228,9 +228,12 @@ prefix no shipped path reaches yet still carries an `UNCONFIRMED` marker.
   `assert_return` / `assert_trap` / `invoke` / `assert_exhaustion` /
   `assert_exception` through the interpreter — SIMD judged per lane (Track
   G) and exception-handling throwing judged (Track H), so the `staged`
-  column is 0. What still skips is host imports the harness does not
-  provide and `assert_unlinkable`. See [docs/testing.md](docs/testing.md)
-  for what is judged versus skipped and the measured tallies.
+  column is 0. The 257 pinned core scripts have no failures or skips;
+  `assert_unlinkable`, the standard `spectest` host, module definitions /
+  instances, and inline-module bodies are judged. Recursive residue belongs
+  only to post-3.0 proposals, testsuite-local custom directives, and the
+  explicitly out-of-scope legacy exception encoding. See
+  [docs/testing.md](docs/testing.md) for the measured tallies.
 - Two framework gotchas, both already worked around in the existing
   suites: FPC will not parse a generic call (`Expect<T>(...)`) as the lone
   statement of an `on ... do`, and the runner fails any test that records

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ it. It is driven by `wasmlight inspect` / `wasmlight validate` /
 conformance corpus in any tier (`--tier=interp|jit|aot`) — assembling text
 modules, validating, instantiating, and executing the assertions, SIMD
 judged per lane and `assert_exception` judged. All three tiers produce
-**byte-identical** corpus results (**65,204 pass**) on both arches.
+**byte-identical** pinned-core results (**65,188 pass, 0 fail, 0 skip**)
+on both compiling tiers locally; CI proves the same identity across the
+supported platform matrix.
 [docs/roadmap.md](docs/roadmap.md) is the honest picture of exactly what
 exists and what remains (broader optimizing-compiler work, the characterized
 non-3.0-core corpus failures, and cross-platform CI validation).
@@ -97,15 +99,17 @@ modules, validating, instantiating, and executing `assert_return` /
 ```text
 $ ./build/wasmspec tests/spec/testsuite
 ...
-ROOT      pass=64671 fail=33  skip=610  staged=0 total=65314
-PROPOSALS pass=533   fail=356 skip=922  staged=0 total=1811
-TOTAL files=288 errors=0 pass=65204 fail=389 skip=1532 staged=0 total=67125
+ROOT pass=65208 fail=14 skip=90 staged=0 total=65312
+PROPOSALS pass=643 fail=354 skip=814 staged=0 total=1811
+TOTAL files=288 errors=0 pass=65851 fail=368 skip=904 staged=0 total=67123
 ```
 
 SIMD is judged per lane (Track G) and exception handling is judged (Track
 H), so `staged` is 0 and the interpreter executes all of core wasm 3.0; the
-failures are dominated by post-3.0 proposals outside the pinned 3.0 target,
-not 3.0 regressions.
+the 257 pinned core scripts are separately clean at `pass=65188 fail=0
+skip=0`. The recursive residue is confined to post-3.0 proposals, the
+explicitly out-of-scope legacy exception encoding, and testsuite-local custom
+directives.
 
 For the full command set and every development command, see
 [docs/quick-start.md](docs/quick-start.md) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -428,8 +428,10 @@ table over the validated IR, so no optimization rewrites or re-validates it.
 `Wasm.Wast.Runner`, which assembles text modules, decodes, validates,
 instantiates, and executes assertions through the interpreter — SIMD judged
 per lane and `assert_exception` judged (Track H), so the `staged` column is
-0 — leaving only host imports and `assert_unlinkable` still ahead. See
-[testing.md](testing.md) for the measured tallies.
+0. It also supplies the standard `spectest` host, judges
+`assert_unlinkable`, and executes module definitions/instances; the pinned
+core scripts have no failures or skips. See [testing.md](testing.md) for the
+measured tallies and the separately classified recursive residue.
 
 ### The embedding API and the host surface
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -107,10 +107,12 @@ TOTAL files=1 errors=0 pass=460 fail=0 skip=0 staged=0 total=460
 ```
 
 A directory argument is walked recursively, and the aggregate splits `ROOT`
-(the 3.0 target) from `PROPOSALS` (post-3.0). Over the whole corpus that is
-`pass=65204 fail=389 skip=1532 staged=0` across 288 files — SIMD judged per
-lane (Track G) and exception handling judged (Track H), so `staged` is 0,
-and the failures are dominated by post-3.0 proposals, not 3.0 regressions.
+(core plus the mirror's `custom/` and `legacy/` trees) from `PROPOSALS`.
+The 257 pinned core scripts are clean at `pass=65188 fail=0 skip=0 staged=0`.
+Over the whole recursive mirror the tally is `pass=65851 fail=368 skip=904
+staged=0` across 288 files; the residue is confined to post-3.0 proposals,
+testsuite-local custom directives, and the explicitly out-of-scope legacy
+exception encoding.
 See [testing.md](testing.md) for what the tallies mean and
 [`tests/spec/README.md`](../tests/spec/README.md) for fetching the corpus.
 
@@ -142,7 +144,8 @@ absolute path is refused before any OS call. Arguments after the module
 Those three programs are the whole shipped surface today: decode, validate,
 instantiate, and execute the **complete core wasm 3.0 instruction set** —
 every numeric, reference, GC, SIMD, and exception-handling instruction —
-conformance-tested against the upstream corpus (~65,204 assertions pass),
+conformance-tested against the pinned core corpus (65,188 pass, no failures or
+skips),
 **and run WASI preview1 command modules** under deny-by-default sandboxing.
 See [roadmap.md](roadmap.md) for what comes next and in what order.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,8 +27,8 @@
   Track H the runtime decodes, validates, instantiates, and **executes all
   of core wasm 3.0** — every category in the counted backlog, SIMD and
   exception handling included. Nothing in the interpreter is staged any
-  more: the harness's `STAGED` column is **0**. The corpus runs at
-  **~65,204 pass** of ~67,000 judged commands with `errors=0`. With Track
+  more: the harness's `STAGED` column is **0**. The 257 pinned core scripts
+  run at **65,188 pass, 0 fail, 0 skip** with `errors=0`. With Track
   F that execution core is now reachable from a host and from the command
   line: `wasmlight run tests/fixtures/wasi/hello.wasm` prints `hello` and
   exits `0`, and a program granted a preopen reads the filesystem through
@@ -62,7 +62,8 @@
   platform), a **baseline JIT** that compiles each function to native code
   at run time, and an **ahead-of-time compiler** that compiles to a
   `.waot` artifact loaded for instant startup. All three produce
-  **byte-identical** corpus results (65,204 pass) on both aarch64 and
+  **byte-identical** pinned-core results (65,188 pass, no failures or skips)
+  on both aarch64 and
   x86-64. The JIT and AOT share **two backends** — `Wasm.Jit.Arm64` and
   `Wasm.Jit.X64` — gated to a 64-bit UNIX host (`WASM_JIT_EXEC`); on
   Windows and 32-bit targets the JIT/AOT are inactive and the runtime is
@@ -81,8 +82,8 @@
   values and expression temporaries across epoch-only back-edges, sparsely
   initialize compiled frames from validation metadata, streamline resolved
   direct-call frame entry/exit, and pin eligible single-memory state in the
-  aarch64 backend. Second, the 389
-  characterized corpus failures, none a 3.0-core gap (see Track C). Third,
+  aarch64 backend. Second, the 368 recursively measured failures, all confined
+  to proposals or the out-of-scope legacy encoding (see Track C). Third,
   cross-platform CI validation on the legs never yet run on real hardware:
   the three-tier identity is proven locally on **aarch64-darwin** (native)
   and **amd64-linux** (a Rosetta VM), and the corpus is **now wired into
@@ -290,29 +291,30 @@ and `assert_invalid` judge the rejection (text operands via
 through the interpreter and compare. `wasmspec` (`source/apps/`) points it
 at the corpus.
 
-Over `WebAssembly/testsuite@de54fd27` that is `pass=65204 fail=389
-skip=1532 staged=0` with `errors=0` across 288 files — the split is
-`ROOT pass=64671 fail=33 staged=0` and `PROPOSALS pass=533 fail=356`.
-Judged commands (`pass + fail`) are **~65,593** of the corpus's ~67,000.
+Over the 257 pinned core scripts that is `pass=65188 fail=0 skip=0
+staged=0` with `errors=0`. The recursive mirror adds custom, legacy, and
+post-3.0 proposal trees and reports `pass=65851 fail=368 skip=904 staged=0`
+across 288 files: `ROOT pass=65208 fail=14 skip=90` and
+`PROPOSALS pass=643 fail=354 skip=814`. Judged recursive commands
+(`pass + fail`) are **66,219** of 67,123.
 The `staged` column is **0**: Track H shipped the throwing that used to
 sit there. `--tier=jit` and `--tier=aot` produce the **same** tally,
-byte-for-byte (jit/aot `compiled=8588` on aarch64), which is the
+byte-for-byte (locally, `compiled=8703` for the pinned core and 8,799 for the
+recursive mirror on aarch64), which is the
 differential proof the two compiling tiers demand
 ([ADR-0001](adr/0001-tiered-execution-seam.md)). See
 [testing.md](testing.md) and
 [`tests/spec/README.md`](../tests/spec/README.md) for the tallies and the
 failure breakdown.
 
-The 389 remaining failures are **not** 3.0-core gaps. `PROPOSALS`
-accounts for 356 of them — post-3.0 features outside the pinned target
+The 368 recursive failures are **not** 3.0-core gaps. `PROPOSALS`
+accounts for 354 of them — post-3.0 features outside the pinned target
 ([ADR-0004](adr/0004-conformance-target-is-the-3-0-draft.md)):
 custom-descriptors, custom-page-sizes, wide-arithmetic, and threads, as
-false rejections (`expected=""`) or wording mismatches. The `ROOT` 33 are
-the legacy `try`/`catch`/`delegate`/`rethrow` encoding (`testsuite/legacy/`,
-out of 3.0 scope — the 3.0 `try_table` form passes), module-definition and
-instance harness forms, and a handful of deferred assembler/decoder framing
-edges. None is a wrong-class rejection, and none is a SIMD or
-exception-handling execution failure.
+false rejections (`expected=""`) or wording mismatches. The 14 root failures
+are all the legacy `try`/`catch`/`delegate`/`rethrow` encoding
+(`testsuite/legacy/`, out of 3.0 scope — the 3.0 `try_table` form passes).
+The pinned core has no failures or skips.
 
 Requirements the corpus imposes, and where each stands:
 
@@ -521,8 +523,9 @@ stay discoverable. It carries the full non-EH op set; a function using
 `throw` / `throw_ref` or hosting a `try_table` handler is declined and
 stays interpreted, and the two tiers interoperate transparently across the
 seam. The correctness proof is differential: `--tier=jit` over the corpus
-is **byte-identical** to `--tier=interp` — `compiled=8588` on aarch64
-(`8589` on x86-64), `pass=65204 fail=389` — on **both** architectures.
+is **byte-identical** to `--tier=interp` — locally `compiled=8703` on
+aarch64, `pass=65188 fail=0 skip=0` — with cross-platform identity enforced
+in CI.
 
 The tier runs only where `WASM_JIT_EXEC` holds — a **64-bit UNIX host**.
 On Windows and 32-bit targets it is inactive and the runtime is
@@ -548,7 +551,8 @@ sibling `<module>.waot` auto-detect and a `--no-aot` opt-out — loads it in
 a fresh process for **instant startup**. It is proven not to be a re-JIT:
 the AOT-loaded executable memory is byte-identical to a fresh compile, and
 `--tier=aot` over the corpus is byte-identical to both other tiers
-(`compiled=8588` on aarch64). Same 64-bit-UNIX scope as Track I.
+(`compiled=8703` on aarch64 for the pinned core). Same 64-bit-UNIX scope as
+Track I.
 
 **Security invariant.** AOT **always re-decodes and re-validates** the
 module at load. The artifact is a per-module perf cache, **never a trust

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,7 @@
 ## Executive Summary
 
 - `lwpt test` discovers, compiles, and runs `source/units/*.Test.pas` as
-  independent programs. Forty-four suites today, 1,188 tests, all green.
+  independent programs. Forty-four suites today, 1,224 tests, all green.
 - Unit suites are co-located with the unit they cover and carry the
   malformed-input cases as literal bytes.
 - The upstream WebAssembly spec testsuite **is wired up** through
@@ -11,9 +11,8 @@
   instantiates, and *executes* `assert_return` / `assert_trap` / `invoke`
   / `assert_exhaustion` / `assert_exception` through the interpreter — SIMD
   judged per lane (Track G) and exception-handling throwing judged (Track
-  H), so the `staged` column is 0. The measured conformance is reported
-  below; what still skips is a few host-import cases and
-  `assert_unlinkable`.
+  H), so the `staged` column is 0. The 257 pinned core scripts are fully
+  judged: 65,188 pass with no failures or skips.
 - Two framework gotchas bite newcomers; both are listed below.
 
 ## Running
@@ -35,7 +34,7 @@ non-zero if any test or compile fails.
 | --- | --- | --- |
 | Co-located unit suites | The decoder and validator match *our reading* of the spec | shipped |
 | Fixture cross-check | It matches *what toolchains actually emit* | shipped |
-| Spec testsuite | It matches *the spec*, judged externally, in every execution tier | shipped — assembles, validates, instantiates, and executes all of core wasm 3.0, SIMD and exception handling judged, over `--tier=interp\|jit\|aot` (all three byte-identical); a few host-import and `assert_unlinkable` edges still skip |
+| Spec testsuite | It matches *the spec*, judged externally, in every execution tier | shipped — assembles, validates, instantiates, and executes all of core wasm 3.0, including the standard `spectest` host, `assert_unlinkable`, module definitions/instances, SIMD, and exception handling, over `--tier=interp\|jit\|aot`; the pinned core tally is byte-identical with no failures or skips |
 
 The middle tier exists because the first two claims are not the same one.
 The section-order bug this project fixed was invisible to hand-written
@@ -181,17 +180,24 @@ through the interpreter and compare. Everything not judged is `SKIP` with a
 reason, and the skip column is never folded into the totals, so a report
 cannot read as more conformance than was measured.
 
-The current run over the whole checkout
-(`WebAssembly/testsuite@de54fd27ecf3e68dfd16b6199c548df77b6a2cc1`):
+The pinned core target (the 257 top-level scripts) is clean:
 
 ```text
-ROOT      pass=64671 fail=33  skip=610  staged=0 total=65314
-PROPOSALS pass=533   fail=356 skip=922  staged=0 total=1811
-TOTAL files=288 errors=0 pass=65204 fail=389 skip=1532 staged=0 total=67125
+ROOT pass=65188 fail=0 skip=0 staged=0 total=65188
+TOTAL files=257 errors=0 pass=65188 fail=0 skip=0 staged=0 total=65188
 ```
 
-Judged commands — `pass + fail` — are **~65,593** of the corpus's
-~67,000. The `staged` column is now **0**: Track H shipped the exception
+The current recursive run, which additionally includes `custom/`, `legacy/`,
+and post-3.0 `proposals/`, is:
+
+```text
+ROOT pass=65208 fail=14 skip=90 staged=0 total=65312
+PROPOSALS pass=643 fail=354 skip=814 staged=0 total=1811
+TOTAL files=288 errors=0 pass=65851 fail=368 skip=904 staged=0 total=67123
+```
+
+Judged commands — `pass + fail` — are **66,219** of the recursive mirror's
+67,123. The `staged` column is now **0**: Track H shipped the exception
 throwing that used to sit there, so `try_table`, `throw`, and `throw_ref`
 execute and `assert_exception` is judged.
 
@@ -200,13 +206,13 @@ This is honest conformance, and it now reaches execution across the
 assembler builds what upstream builds, the validator rejects what upstream
 rejects with the right class and a prefix-matching message, and the
 interpreter produces the results — lane by lane for `v128` — the traps, and
-the exceptions the corpus asserts. The 389 failures are **not** 3.0-core
-gaps — 356 of them are `PROPOSALS` (post-3.0 features outside the pinned
-target), and the 33 `ROOT` failures are the legacy `try`/`catch`/`delegate`/
-`rethrow` encoding (out of 3.0 scope), module-definition/instance harness
-forms, and a few deferred decode/framing edges (see
-[`tests/spec/README.md`](../tests/spec/README.md)). None is a SIMD or
-exception-handling execution failure.
+the exceptions the corpus asserts. The 368 recursive failures are **not**
+3.0-core gaps: 354 are `PROPOSALS` (post-3.0 features outside the pinned
+target), and all 14 `ROOT` failures are the legacy
+`try`/`catch`/`delegate`/`rethrow` encoding, which is explicitly outside the
+3.0 target. The 90 root skips are 20 testsuite-local custom directives and 70
+commands downstream of those legacy modules. The pinned core itself has no
+failure or skip.
 
 `STAGED` remains a distinct status in the harness — a case attempted and
 deliberately set aside, never counted as a pass — but nothing populates it
@@ -235,14 +241,21 @@ the column reads 0.
 5. **Per-lane SIMD comparison — met.** `assert_return` over a `v128`
    result compares each lane at the shape's width (Track G), so a
    `nan:canonical` lane can sit beside an exact one.
-6. **Host references** — `(ref.extern n)` (140) and `(ref.host n)` — parse
-   into identity matchers in `Wasm.Wast.Values`; imports the harness does
-   not provide still skip (`import not provided by the harness`).
+6. **Host references and imports — met.** `(ref.extern n)` (140) and
+   `(ref.host n)` parse into identity matchers. The pinned standard `spectest`
+   functions, globals, i32/i64 tables, and memory are allocated once per
+   script and shared by every module.
+7. **Linkage and script module forms — met.** `assert_unlinkable` is judged by
+   the real instantiator's `EWasmLinkError`; named definitions are retained and
+   instantiated generatively; an elided outer module wrapper is treated as one
+   inline module body.
 
-What still skips, never as a silent pass: host imports the harness does
-not provide, and `assert_unlinkable` (linkage is not yet judged).
-Exception handling no longer skips — `assert_exception` is judged and the
-throwing forms execute (Track H). Two traps, both handled:
+The pinned core has no skips. Recursive-only skips remain honest: the custom
+tree's `assert_malformed_custom` and `assert_invalid_custom` directives are
+testsuite-local extensions absent from the reference grammar, and legacy
+commands have no instance after their intentionally unsupported module form
+fails. Exception handling in core does not skip — `assert_exception` is judged
+and the 3.0 throwing forms execute (Track H). Two reporting traps remain:
 `assert_malformed_custom` and `assert_invalid_custom` are testsuite-local
 extensions absent from the reference grammar, so the runner classifies
 them as unknown and skips rather than choking; and `assert_return` is 83%
@@ -256,10 +269,10 @@ All three execution tiers exist, so the harness runs per tier —
 `wasmspec --tier=interp|jit|aot` — and the suite doubles as the
 differential test between them: every tier must produce identical outcomes
 ([ADR-0001](adr/0001-tiered-execution-seam.md)). It does. Over the pinned
-`testsuite@de54fd27`, all three tiers report `pass=65204 fail=389
-staged=0` byte-for-byte, with the two compiling tiers reporting
-`compiled=8588` functions on aarch64 (`compiled=8589` on x86-64 — one more
-function clears the scope fence there). The JIT and AOT tiers run only on a
+`testsuite@de54fd27`, all three tiers report the pinned-core tally
+`pass=65188 fail=0 skip=0 staged=0` byte-for-byte. The local aarch64 run
+compiled 8,703 functions in each compiling tier (8,799 over the recursive
+mirror). The JIT and AOT tiers run only on a
 64-bit UNIX host (`WASM_JIT_EXEC`); on Windows and 32-bit targets the
 interpreter runs alone.
 

--- a/source/apps/wasmspec.pas
+++ b/source/apps/wasmspec.pas
@@ -6,16 +6,14 @@
   Wasm.Wast.Runner judges the commands it can judge, and everything here
   is argument handling and reporting.
 
-  WHAT A RUN MEANS TODAY. The interpreter tier is wired in (Track E), so
-  `(module binary ...)` cases now decode, validate, INSTANTIATE, and run:
-  top-level modules, `assert_malformed`/`assert_invalid`, and the action
-  and result assertions (`assert_return`, `assert_trap`,
-  `assert_exhaustion`, `invoke`, `register`, `get`). There is still no
-  text-format assembler, so the overwhelming majority of the corpus — which
-  spells its modules in the text format — is SKIPPED with a reason until
-  that lands (Track C). The skip column is never folded into the totals: a
-  report from this program must not read as more conformance than was
-  actually measured.
+  WHAT A RUN MEANS TODAY. Text, quote, binary, and inline module bodies are
+  assembled or decoded, validated, instantiated, and run. The harness judges
+  malformed, invalid, unlinkable, return, trap, exhaustion, exception,
+  invoke, register, and get commands; provides the pinned standard `spectest`
+  imports; and supports generative module definitions/instances. The skip
+  column remains distinct for commands outside the reference grammar or an
+  unavailable instance, so a recursive proposal/custom run never reads as
+  more conformance than was actually measured.
 
   OUTPUT IS ONE LINE PER FACT, on stdout, in a fixed leading-token shape
   (`FAIL`, `STAGED`, `SKIP`, `PASS`, `FILE`, `TOTAL`, `ERROR`) so a run
@@ -253,9 +251,10 @@ begin
   Write(GenerateHelpText(TOOL_NAME, '[options] <script.wast|directory>...',
     AOptions));
   WriteLn;
-  WriteLn('Only (module binary ...) cases are judged: modules decode, validate,');
-  WriteLn('and run (assert_return/assert_trap/assert_exhaustion/invoke). Text-format');
-  WriteLn('modules still need the assembler and are reported as SKIP. Exit code is 0');
+  WriteLn('Text, quote, binary, and inline modules are assembled or decoded,');
+  WriteLn('validated, instantiated, and run through the selected tier. Standard');
+  WriteLn('spectest imports, linkage assertions, and module instances are judged.');
+  WriteLn('Exit code is 0');
   WriteLn('only when nothing failed and every script could be read and parsed.');
 end;
 

--- a/source/units/Wasm.Binary.Test.pas
+++ b/source/units/Wasm.Binary.Test.pas
@@ -398,6 +398,9 @@ begin
   { Declares nine bytes, supplies two. }
   ExpectRejected('name', 'name longer than the input',
     [$09, Ord('a'), Ord('b')]);
+  ExpectMessagePrefix('name', 'name length past physical input',
+    MSG_LENGTH_OUT_OF_BOUNDS, [$09, Ord('a'), Ord('b')], wrcTopLevel);
+
 end;
 
 procedure TBinaryTests.TestSubReaderIsBounded;

--- a/source/units/Wasm.Binary.pas
+++ b/source/units/Wasm.Binary.pas
@@ -49,6 +49,9 @@ const
     is satisfied by either. }
   MSG_UNEXPECTED_END = 'unexpected end';
   MSG_UNEXPECTED_END_OF_SECTION = 'unexpected end of section or function';
+  { A function-code expression reached its declared entry boundary while the
+    code section still contains a following entry. }
+  MSG_END_OPCODE_EXPECTED = 'END opcode expected';
 
   { LEB128. `too large` is a value that does not fit the width; `too
     long` is an encoding that spends more bytes than the width allows,
@@ -122,17 +125,25 @@ type
       the reader borrows the buffer and never owns it. }
     procedure Init(const AData: PByte; const ASize: NativeUInt);
     procedure InitFromBytes(const ABytes: TWasmBytes);
+    { A logically bounded span over a larger physical module buffer. LEB128
+      readers may inspect past the span to classify an overlong or over-wide
+      integer before the enclosing size mismatch is reported; every other
+      read remains bounded by ASize. }
+    procedure InitSpanFromBytes(const ABytes: TWasmBytes;
+      const AOffset, ASize: NativeUInt);
 
     function Eof: Boolean; inline;
     function Remaining: NativeUInt; inline;
 
     function ReadByte: Byte;
     function PeekByte: Byte;
+    function PeekPhysicalByte: Byte;
 
     { LEB128. The `A32`/`A64` suffix is the value's width, not the
       encoding's length. }
     function ReadU32: UInt32;
     function ReadU64: UInt64;
+    function ReadS7: Int8;
     function ReadI32: Int32;
     function ReadI64: Int64;
 
@@ -172,6 +183,10 @@ type
       callers that detect exhaustion themselves (a vector count larger
       than the bytes left) rather than by reading past the end. }
     function EndOfInputPrefix: string;
+    { Bytes physically present after the reader's logical span. Used only by
+      decoders whose reference diagnostic depends on whether the module
+      continues beyond an exhausted section. }
+    function PhysicalRemaining: NativeUInt;
 
     property Position: NativeUInt read FPos write SetPosition;
     property Size: NativeUInt read FSize;
@@ -227,6 +242,24 @@ begin
     Init(@ABytes[0], Length(ABytes));
 end;
 
+procedure TWasmReader.InitSpanFromBytes(const ABytes: TWasmBytes;
+  const AOffset, ASize: NativeUInt);
+var
+  BufferSize: NativeUInt;
+begin
+  BufferSize := NativeUInt(Length(ABytes));
+  if (AOffset > BufferSize) or (ASize > BufferSize - AOffset) then
+    raise EWasmDecodeError.CreateFmt(
+      'reader span [%u, %u) runs past a %u-byte buffer',
+      [AOffset, AOffset + ASize, BufferSize]);
+
+  if BufferSize = 0 then
+    Init(nil, 0)
+  else
+    Init(@ABytes[AOffset], ASize);
+  FCapacity := BufferSize - AOffset;
+end;
+
 function TWasmReader.Eof: Boolean;
 begin
   Result := FPos >= FSize;
@@ -238,6 +271,14 @@ begin
     Result := 0
   else
     Result := FSize - FPos;
+end;
+
+function TWasmReader.PhysicalRemaining: NativeUInt;
+begin
+  if FPos >= FCapacity then
+    Result := 0
+  else
+    Result := FCapacity - FPos;
 end;
 
 procedure TWasmReader.SetPosition(const AValue: NativeUInt);
@@ -274,6 +315,15 @@ end;
 function TWasmReader.PeekByte: Byte;
 begin
   Need(1, 'byte');
+  Result := FData[FPos];
+end;
+
+function TWasmReader.PeekPhysicalByte: Byte;
+begin
+  if FPos >= FCapacity then
+    raise EWasmDecodeError.CreateFmt(
+      '%s: reading byte at offset %u (need 1 byte(s), 0 left)',
+      [EndOfInputPrefix, FPos]);
   Result := FData[FPos];
 end;
 
@@ -471,6 +521,11 @@ begin
   Result := ReadUnsigned(64, 'u64');
 end;
 
+function TWasmReader.ReadS7: Int8;
+begin
+  Result := Int8(ReadSigned(7, 's7'));
+end;
+
 function TWasmReader.ReadI32: Int32;
 begin
   Result := Int32(ReadSigned(32, 's32'));
@@ -558,6 +613,17 @@ var
   Start: NativeUInt;
 begin
   Len := ReadU32;
+  { A name is a byte list (`binary-name` -> `binary-list`). Distinguish a
+    list whose declared byte length runs past the PHYSICAL module buffer
+    from one merely cut by its enclosing section: the former is the
+    reference decoder's `length out of bounds`, while the latter remains
+    the section-context truncation raised by Need below. Sub-readers retain
+    the physical capacity specifically so framing does not hide a malformed
+    width or length that can already be proved from the whole buffer. }
+  if NativeUInt(Len) > FCapacity - FPos then
+    raise EWasmDecodeError.CreateFmt(
+      '%s: name at offset %u declares %u byte(s) but only %u remain',
+      [MSG_LENGTH_OUT_OF_BOUNDS, FPos, Len, FCapacity - FPos]);
   Need(Len, 'name');
   Start := FPos;
 

--- a/source/units/Wasm.Decoder.Entities.Test.pas
+++ b/source/units/Wasm.Decoder.Entities.Test.pas
@@ -61,6 +61,8 @@ type
     procedure TestGlobalRejectsMalformed;
     procedure TestExportsIncludingDuplicateName;
     procedure TestExportRejectsMalformed;
+    procedure TestExportCountPastSectionIsLengthOutOfBounds;
+    procedure TestEmptyNamePastExportSectionStaysUnexpectedEnd;
     procedure TestStartSection;
     procedure TestStartRejectsMalformed;
     procedure TestTagSection;
@@ -389,6 +391,46 @@ begin
   ExpectRejected('export', 'leftover byte after content', [$00, $00]);
 end;
 
+procedure TDecoderEntitiesTests.TestExportCountPastSectionIsLengthOutOfBounds;
+var
+  Parent, Body: TWasmReader;
+  Actual: string;
+begin
+  { The export body declares two entries but contains one. The trailing $0A
+    is the next section id in the physical module, outside the six-byte body. }
+  Parent := ReaderOver([$02, $02, $66, $31, $00, $00, $0A]);
+  Parent.Context := wrcSection;
+  Body := Parent.SubReader(6);
+  Actual := '<not rejected>';
+  try
+    DecodeExportSection(Body, 0, FModule);
+  except
+    on E: EWasmDecodeError do
+      Actual := E.Message;
+  end;
+  Expect<string>(Copy(Actual, 1, Length(MSG_LENGTH_OUT_OF_BOUNDS)))
+    .ToBe(MSG_LENGTH_OUT_OF_BOUNDS);
+end;
+
+procedure TDecoderEntitiesTests.TestEmptyNamePastExportSectionStaysUnexpectedEnd;
+var
+  Parent, Body: TWasmReader;
+  Actual: string;
+begin
+  Parent := ReaderOver([$02, $02, $66, $31, $00, $00, $00]);
+  Parent.Context := wrcSection;
+  Body := Parent.SubReader(6);
+  Actual := '<not rejected>';
+  try
+    DecodeExportSection(Body, 0, FModule);
+  except
+    on E: EWasmDecodeError do
+      Actual := E.Message;
+  end;
+  Expect<string>(Copy(Actual, 1, Length(MSG_UNEXPECTED_END_OF_SECTION)))
+    .ToBe(MSG_UNEXPECTED_END_OF_SECTION);
+end;
+
 procedure TDecoderEntitiesTests.TestStartSection;
 var
   R: TWasmReader;
@@ -488,6 +530,10 @@ begin
   Test('exports including a duplicate name',
     TestExportsIncludingDuplicateName);
   Test('exports reject malformed forms', TestExportRejectsMalformed);
+  Test('export count past section is length out of bounds',
+    TestExportCountPastSectionIsLengthOutOfBounds);
+  Test('empty name past export section stays unexpected end',
+    TestEmptyNamePastExportSectionStaysUnexpectedEnd);
   Test('start section', TestStartSection);
   Test('start section rejects malformed forms', TestStartRejectsMalformed);
   Test('tag section', TestTagSection);

--- a/source/units/Wasm.Decoder.Entities.pas
+++ b/source/units/Wasm.Decoder.Entities.pas
@@ -243,6 +243,23 @@ begin
   Count := ReadVecCount(ABody, 'export');
   for I := 1 to Count do
   begin
+    { The reference decoder consumes vector entries from the physical stream
+      before checking the export section's declared size. If the vector count
+      promises another named entry exactly at the section boundary and the
+      module continues, it reports the name list as out of bounds rather than
+      generic section truncation. Keep this narrow to exports: other entity
+      productions have different confirmed prefixes for the same geometry. }
+    if ABody.Eof and (ABody.PhysicalRemaining > 0)
+      { In binary.wast:737 the next section's one-byte id is consumed as the
+        missing export's one-byte name length, but the declared bytes do not
+        physically remain. Do not generalize this to `$00` (an empty name) or
+        a continued u32; those retain the ordinary section-truncation
+        diagnosis. }
+      and ((ABody.PeekPhysicalByte and $80) = 0)
+      and (ABody.PhysicalRemaining < 1 + ABody.PeekPhysicalByte) then
+      raise EWasmDecodeError.CreateFmt(
+        '%s: export name starts at section boundary offset %u',
+        [MSG_LENGTH_OUT_OF_BOUNDS, ABase + ABody.Position]);
     Entry.Name := ABody.ReadName;
     Entry.Kind := ReadExternKind(ABody, ABase, MSG_MALFORMED_EXPORT_KIND);
     Entry.Index := ABody.ReadU32;

--- a/source/units/Wasm.Decoder.Segments.pas
+++ b/source/units/Wasm.Decoder.Segments.pas
@@ -5,9 +5,11 @@
   spans (ADR-0003): element offset and init expressions, function
   bodies, and data bytes are located but never copied and never
   interpreted. Expressions are delimited by Wasm.Decoder.Expr's skipper;
-  function bodies are bounded by the code entry's size prefix and are
-  deliberately NOT instruction-walked here — the fused validation walk
-  owns the instruction grammar inside them (ADR-0007).
+  function bodies are bounded by the code entry's size prefix and are not
+  instruction-walked here on the valid path — the fused validation walk owns
+  their instruction grammar (ADR-0007). A body whose declared last byte is
+  not `end` gets a decode-only probe so an overlong integer split by that
+  framing boundary keeps its `binary-int` diagnosis.
 
   Everything raised here is EWasmDecodeError, because everything checked
   here is the binary grammar: an unassigned segment flag value, a
@@ -249,7 +251,7 @@ var
   I: UInt32;
   EntrySize: UInt32;
   EntryBase: NativeUInt;
-  Entry: TWasmReader;
+  Entry, Probe: TWasmReader;
   CodeEntry: TWasmCodeEntry;
   GroupCount: UInt32;
   G: UInt32;
@@ -298,6 +300,31 @@ begin
         'code entry at offset %u has no function body',
         [EntryBase]);
     CodeEntry.Body := MakeSpan(EntryBase + Entry.Position, Entry.Remaining);
+
+    { `binary-code` makes the size a framing assertion, not a license for an
+      integer encoding to escape the entry and be reinterpreted as section
+      ids. A correctly framed expression ends in $0B, so keep that overwhelmingly
+      common path on ADR-0007's single fused walk. Otherwise probe the grammar
+      on a COPY: ordinary syntax and typing remain fused in validation, but a
+      width-limited LEB may inspect physical bytes after the logical entry
+      bound. If that proves the integer overlong/over-wide, preserve its
+      binary-int diagnosis before the outer section walk sees continuation
+      bytes. }
+    Probe := Entry;
+    Probe.Position := Probe.Size - 1;
+    if Probe.ReadByte <> $0B then
+    begin
+      Probe := Entry;
+      try
+        SkipExpr(Probe, EntryBase);
+      except
+        on E: EWasmDecodeError do
+        begin
+          if Probe.Position > Probe.Size then
+            raise;
+        end;
+      end;
+    end;
 
     AModule.AddCodeEntry(CodeEntry);
   end;

--- a/source/units/Wasm.Decoder.Test.pas
+++ b/source/units/Wasm.Decoder.Test.pas
@@ -77,6 +77,7 @@ type
     procedure TestPreamblePrefixesSplitMagicFromTruncation;
     procedure TestSectionWalkMessagePrefixes;
     procedure TestCustomSectionErrorKeepsItsPrefix;
+    procedure TestLebDiagnosticsSurviveCodeEntryFraming;
   end;
 
 procedure TDecoderTests.BuildModule(const AValues: array of Byte);
@@ -662,6 +663,55 @@ begin
     RejectionMessage([$00, $20, $01, $61]), MSG_LENGTH_OUT_OF_BOUNDS);
 end;
 
+procedure TDecoderTests.TestLebDiagnosticsSurviveCodeEntryFraming;
+const
+  PREFIX: array[0..16] of Byte = (
+    $01, $04, $01, $60, $00, $00,       { type: () -> () }
+    $03, $02, $01, $00,                   { one function of type 0 }
+    $05, $03, $01, $00, $01,              { one i32 memory }
+    $0A, $0B);                             { code section, 11-byte body }
+var
+  Values: TWasmBytes;
+
+  function WithTail(const ATail: array of Byte): TWasmBytes;
+  var
+    I: Integer;
+  begin
+    SetLength(Result, Length(PREFIX) + Length(ATail));
+    for I := 0 to High(PREFIX) do
+      Result[I] := PREFIX[I];
+    for I := 0 to High(ATail) do
+      Result[Length(PREFIX) + I] := ATail[I];
+  end;
+
+begin
+  { The code entry declares nine payload bytes. Its memarg u64 begins in
+    that span but completes beyond it. `binary-int` still owns the integer's
+    width diagnosis; the continuation bytes must not become section ids. }
+  Values := WithTail([
+    $01, $09,                               { one entry, size 9 }
+    $00, $41, $00, $28, $02,                { locals; i32.const; load; align }
+    $82, $80, $80, $80,                     { first four u64 bytes in entry }
+    $80, $80, $80, $80, $80, $80, $00]);   { overlong continuation }
+  AssertMessagePrefix('overlong memarg clipped by code entry',
+    RejectionMessage(Values), MSG_INTEGER_TOO_LONG);
+
+  Values := WithTail([
+    $01, $09,
+    $00, $41, $00, $28, $02,
+    $82, $80, $80, $80,
+    $80, $80, $80, $80, $80, $10]);        { unused u64 bits set }
+  AssertMessagePrefix('over-wide memarg clipped by code entry',
+    RejectionMessage(Values), MSG_INTEGER_TOO_LARGE);
+
+  { `binary-comptype` uses the signed seven-bit discriminator space. $E0
+    claims a continuation byte, which exceeds s7's one-byte limit before it
+    can be treated as an unknown composite form. }
+  AssertMessagePrefix('overlong composite-type discriminator',
+    RejectionMessage([$01, $05, $01, $E0, $7F, $00, $00]),
+    MSG_INTEGER_TOO_LONG);
+end;
+
 procedure TDecoderTests.SetupTests;
 begin
   Test('decodes a module with no sections', TestEmptyModule);
@@ -702,6 +752,8 @@ begin
     TestSectionWalkMessagePrefixes);
   Test('a custom section failure keeps its own prefix',
     TestCustomSectionErrorKeepsItsPrefix);
+  Test('LEB diagnostics survive code-entry framing',
+    TestLebDiagnosticsSurviveCodeEntryFraming);
 end;
 
 begin

--- a/source/units/Wasm.Decoder.Types.pas
+++ b/source/units/Wasm.Decoder.Types.pas
@@ -131,20 +131,27 @@ end;
 { comptype ::= $60 functype' | $5F structtype | $5E arraytype.
   https://webassembly.github.io/spec/core/binary/types.html#binary-comptype }
 function ReadCompType(var AReader: TWasmReader): TWasmCompType;
+const
+  COMP_FUNC = -32;   { s7 encoding $60 }
+  COMP_STRUCT = -33; { s7 encoding $5F }
+  COMP_ARRAY = -34;  { s7 encoding $5E }
 var
   Start: NativeUInt;
-  Form: Byte;
+  Form: Int8;
   StructType: TWasmStructType;
   ArrayType: TWasmArrayType;
   Count: UInt32;
   I: UInt32;
 begin
   Start := AReader.Position;
-  Form := AReader.ReadByte;
+  { `binary-comptype`'s discriminators inhabit the signed seven-bit code
+    space. Their legal encodings are therefore exactly one byte: an apparent
+    continuation is an overlong s7 integer, not an unrelated unknown form. }
+  Form := AReader.ReadS7;
   case Form of
-    BYTE_FUNC:
+    COMP_FUNC:
       Result := MakeFuncCompType(ReadFuncType(AReader));
-    BYTE_STRUCT:
+    COMP_STRUCT:
       begin
         Count := ReadVecCount(AReader, 'field');
         SetLength(StructType.Fields, Count);
@@ -152,14 +159,14 @@ begin
           StructType.Fields[I - 1] := ReadFieldType(AReader);
         Result := MakeStructCompType(StructType);
       end;
-    BYTE_ARRAY:
+    COMP_ARRAY:
       begin
         ArrayType.Elem := ReadFieldType(AReader);
         Result := MakeArrayCompType(ArrayType);
       end;
   else
     raise EWasmDecodeError.CreateFmt(
-      'malformed composite type $%.2x at offset %u', [Form, Start]);
+      'malformed composite type %d at offset %u', [Form, Start]);
   end;
 end;
 

--- a/source/units/Wasm.Interp.Test.pas
+++ b/source/units/Wasm.Interp.Test.pas
@@ -318,7 +318,7 @@ begin
   { Test-scale reservations: small enough to be cheap per store, large enough
     for every module here. A test may shrink them further before instantiate. }
   WasmInterpValueSlots := 1 shl 16;
-  WasmInterpMaxDepth := 1024;
+  WasmInterpMaxDepth := 256;
 end;
 
 procedure TInterpTests.AfterEach;

--- a/source/units/Wasm.Interp.Test.pas
+++ b/source/units/Wasm.Interp.Test.pas
@@ -318,7 +318,7 @@ begin
   { Test-scale reservations: small enough to be cheap per store, large enough
     for every module here. A test may shrink them further before instantiate. }
   WasmInterpValueSlots := 1 shl 16;
-  WasmInterpMaxDepth := 8192;
+  WasmInterpMaxDepth := 1024;
 end;
 
 procedure TInterpTests.AfterEach;

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -170,7 +170,7 @@ var
     assert_exhaustion trip a small cap deterministically. A push past EITHER
     cap traps 'call stack exhausted'. }
   WasmInterpValueSlots: NativeUInt = 1 shl 20;   { 1 Mi slots = 8 MiB }
-  WasmInterpMaxDepth: NativeUInt = 1 shl 10;     { 1 Ki activation records }
+  WasmInterpMaxDepth: NativeUInt = 1 shl 8;      { 256 activation records }
 
 { Set AStore.TierInvoke/TierContext/TierContextFree so the store runs guest
   code through this interpreter. Allocates the per-store context (the two

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -170,7 +170,7 @@ var
     assert_exhaustion trip a small cap deterministically. A push past EITHER
     cap traps 'call stack exhausted'. }
   WasmInterpValueSlots: NativeUInt = 1 shl 20;   { 1 Mi slots = 8 MiB }
-  WasmInterpMaxDepth: NativeUInt = 8192;         { activation records }
+  WasmInterpMaxDepth: NativeUInt = 1 shl 10;     { 1 Ki activation records }
 
 { Set AStore.TierInvoke/TierContext/TierContextFree so the store runs guest
   code through this interpreter. Allocates the per-store context (the two

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -1252,7 +1252,7 @@ begin
   FImports.Globals := nil;
   FImports.Tags := nil;
   WasmInterpValueSlots := 1 shl 16;
-  WasmInterpMaxDepth := 8192;
+  WasmInterpMaxDepth := 1024;
   FDiffCompile := nil;
   FDiffResultSlots := 1;
   FDiffCompiledAll := False;
@@ -2545,7 +2545,7 @@ begin
     Expect<string>(TrapMessageOf(RecurseModuleBytes, 'rec',
       [MakeValueI32(4000)])).ToBe('call stack exhausted');
   finally
-    WasmInterpMaxDepth := 8192;
+    WasmInterpMaxDepth := 1024;
   end;
 end;
 

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -1252,7 +1252,7 @@ begin
   FImports.Globals := nil;
   FImports.Tags := nil;
   WasmInterpValueSlots := 1 shl 16;
-  WasmInterpMaxDepth := 1024;
+  WasmInterpMaxDepth := 256;
   FDiffCompile := nil;
   FDiffResultSlots := 1;
   FDiffCompiledAll := False;
@@ -2545,7 +2545,7 @@ begin
     Expect<string>(TrapMessageOf(RecurseModuleBytes, 'rec',
       [MakeValueI32(4000)])).ToBe('call stack exhausted');
   finally
-    WasmInterpMaxDepth := 1024;
+    WasmInterpMaxDepth := 256;
   end;
 end;
 

--- a/source/units/Wasm.Validator.Body.Test.pas
+++ b/source/units/Wasm.Validator.Body.Test.pas
@@ -1098,7 +1098,7 @@ begin
     Code1(B([$00]), B([$0B, $0B])));
 
   ExpectMalformed('a trailing byte after the body''s end',
-    MSG_BODY_SIZE_MISMATCH);
+    MSG_SECTION_SIZE_MISMATCH);
 end;
 
 { `binary-if` admits $05 in exactly one place and at most once. }

--- a/source/units/Wasm.Validator.Body.pas
+++ b/source/units/Wasm.Validator.Body.pas
@@ -72,20 +72,6 @@ const
     (RequireDataCount). }
   MSG_DATA_COUNT_REQUIRED = 'data count section required';
 
-  { The body's `end` is not the span's last byte. `binary-code`'s side
-    condition ("the size does not match the length of the respective
-    function code") is binary grammar however late it is found, so this
-    is a decode error; Wasm.Decoder.Common already unified the leftover-
-    bytes family on this prefix. UNCONFIRMED as a prefix match, and it
-    stays that way after the first corpus run: no `(module binary ...)`
-    case reaches it. The nearby case that looks like it does —
-    binary.wast's "missing end marker at end of code sections", which
-    upstream reports as `section size mismatch` — reaches the OPPOSITE
-    condition here, the span running out before the `end`, and that is
-    `unexpected end of section or function` by the reader's context.
-    See tests/spec/README.md on why the two cannot both be matched. }
-  MSG_BODY_SIZE_MISMATCH = 'section size mismatch';
-
   { An engine capacity refusal, and DELIBERATELY NOT A GRAMMAR RULE.
     `syntax-list` bounds a list at 2^32-1 elements and `binary-code`
     makes an expanded locals sequence above that MALFORMED — Track A's
@@ -1337,6 +1323,12 @@ type
     FReader: TWasmReader;
     FBase: NativeUInt;
     FBodySize: NativeUInt;
+    { Absolute code-section end, plus the physical byte just after this body.
+      The fused walk needs both encoded boundaries to classify a missing END
+      without widening the reader past its declared body span. }
+    FCodeSectionEnd: NativeUInt;
+    FHasByteAfterBody: Boolean;
+    FByteAfterBody: Byte;
 
     FFn: TWasmIrFunction;
     FCodeCount: Integer;
@@ -4735,6 +4727,8 @@ var
   C: UInt32;
   Total: UInt64;
   MergeRegs: TWasmRegList;
+  CodeSectionIndex: Integer;
+  BodyEnd: NativeUInt;
 begin
   FModule := AModule;
   FTypes := AContext;
@@ -4877,7 +4871,18 @@ begin
 
   FBase := AEntry.Body.Offset;
   FBodySize := AEntry.Body.Size;
-  FReader.Init(@ABytes[AEntry.Body.Offset], AEntry.Body.Size);
+  BodyEnd := FBase + FBodySize;
+  FCodeSectionEnd := BodyEnd;
+  CodeSectionIndex := AModule.IndexOfSection(wsCode);
+  if CodeSectionIndex >= 0 then
+    FCodeSectionEnd := AModule[CodeSectionIndex].BodyOffset
+      + AModule[CodeSectionIndex].BodySize;
+  FHasByteAfterBody := BodyEnd < NativeUInt(Length(ABytes));
+  if FHasByteAfterBody then
+    FByteAfterBody := ABytes[BodyEnd]
+  else
+    FByteAfterBody := 0;
+  FReader.InitSpanFromBytes(ABytes, AEntry.Body.Offset, AEntry.Body.Size);
   { A function body is one of the two things upstream means by "section
     or function": running off its end reports as such, not as running off
     the end of the module. }
@@ -4901,6 +4906,22 @@ begin
   Done := False;
   while not Done do
   begin
+    { The reference decoder reads the expression before checking code and
+      section sizes (`binary-code`, `binary-section`). This fused walk stays
+      bounded, so reproduce that structural classification from the encoded
+      extents before the reader reports generic truncation. A true physical
+      EOF deliberately falls through and remains `unexpected end of section
+      or function`. }
+    if FReader.Eof then
+    begin
+      if FBase + FBodySize < FCodeSectionEnd then
+        DecErr(Format('%s: function body at offset %u',
+          [MSG_END_OPCODE_EXPECTED, FBase]));
+      if (FBase + FBodySize = FCodeSectionEnd) and FHasByteAfterBody
+        and (FByteAfterBody = $0B) then
+        DecErr(Format('%s: function body at offset %u terminates outside '
+          + 'the declared code section', [MSG_SECTION_SIZE_MISMATCH, FBase]));
+    end;
     OpOffset := FBase + FReader.Position;
     Op := FReader.ReadByte;
 
@@ -5040,7 +5061,7 @@ begin
     a function body, so if the check is not made here it is made nowhere. }
   if FReader.Position <> FBodySize then
     DecErr(Format('%s: function body at offset %u ends %u byte(s) before '
-      + 'its declared extent', [MSG_BODY_SIZE_MISMATCH, FBase,
+      + 'its declared extent', [MSG_SECTION_SIZE_MISMATCH, FBase,
       FBodySize - FReader.Position]));
 
   { The three geometrically grown arrays are trimmed HERE, in the same

--- a/source/units/Wasm.Validator.Test.pas
+++ b/source/units/Wasm.Validator.Test.pas
@@ -29,6 +29,7 @@ uses
   SysUtils,
 
   TestingPascalLibrary,
+  Wasm.Binary,
   Wasm.Core,
   Wasm.Decoder,
   Wasm.Ir,
@@ -73,6 +74,8 @@ type
       else — 'ACCEPTED', a different message, a decode error — verbatim,
       so a case that fails for the wrong reason says which. }
     function RejectionOf(const APrefix: string): string;
+    { Like RejectionOf, but requires the malformed/decode class. }
+    function MalformedRejectionOf(const APrefix: string): string;
     { Builds the fixed multi-section module every positive leans on. }
     procedure BuildKitchenSink;
     procedure ExpectCount(const AWhat: string;
@@ -96,6 +99,8 @@ type
     procedure TestNonNullElemSegmentIntoAFuncrefTable;
     procedure TestFuncidxShorthandIntoANonNullableTable;
     procedure TestImpliedFuncrefExprFormIntoANonNullableTable;
+    procedure TestMissingEndBeforeNextCodeEntry;
+    procedure TestMissingEndConsumesNextSectionByte;
 
     procedure TestRejectsDuplicateExportName;
     procedure TestRejectsMemory64OverThePageLimit;
@@ -223,6 +228,19 @@ begin
       Result := PrefixOutcome(E.Message, APrefix);
     on E: EWasmDecodeError do
       Result := 'decode error: ' + E.Message;
+  end;
+end;
+
+function TValidatorTests.MalformedRejectionOf(const APrefix: string): string;
+begin
+  Result := 'ACCEPTED';
+  try
+    FinishAndValidate;
+  except
+    on E: EWasmDecodeError do
+      Result := PrefixOutcome(E.Message, APrefix);
+    on E: EWasmValidationError do
+      Result := 'validation error: ' + E.Message;
   end;
 end;
 
@@ -1042,6 +1060,43 @@ begin
   Expect<string>(Outcome).ToBe('rejected: ' + MSG_TYPE_MISMATCH);
 end;
 
+{ `binary-code`: the first entry's size ends after `drop`, with another entry
+  still inside the same code section. The fused body walk is the first pass to
+  see that the expression has no outer END and must diagnose that structural
+  condition, not generic reader exhaustion. Literal bytes mirror
+  binary.wast:55 so a framing change cannot be hidden by a size helper. }
+procedure TValidatorTests.TestMissingEndBeforeNextCodeEntry;
+begin
+  FBuf.Reset;
+  FBuf.AddMany([
+    $00, $61, $73, $6D, $01, $00, $00, $00,
+    $01, $04, $01, $60, $00, $00,
+    $03, $03, $02, $00, $00,
+    $0A, $0C, $02,
+    $04, $00, $41, $01, $1A,
+    $05, $00, $41, $01, $1A, $0B]);
+  Expect<string>(MalformedRejectionOf(MSG_END_OPCODE_EXPECTED))
+    .ToBe('rejected: ' + MSG_END_OPCODE_EXPECTED);
+end;
+
+{ `binary-section`: the code section declares six bytes and its lone entry
+  lacks END. The immediately following data-section id is also opcode $0B;
+  an unbounded reference decoder consumes it as END and then proves the code
+  section was larger than declared. The fused bounded walk reaches the same
+  structural result from the declared and physical extents. }
+procedure TValidatorTests.TestMissingEndConsumesNextSectionByte;
+begin
+  FBuf.Reset;
+  FBuf.AddMany([
+    $00, $61, $73, $6D, $01, $00, $00, $00,
+    $01, $04, $01, $60, $00, $00,
+    $03, $02, $01, $00,
+    $0A, $06, $01, $04, $00, $41, $01, $1A,
+    $0B, $03, $01, $01, $00]);
+  Expect<string>(MalformedRejectionOf(MSG_SECTION_SIZE_MISMATCH))
+    .ToBe('rejected: ' + MSG_SECTION_SIZE_MISMATCH);
+end;
+
 procedure TValidatorTests.SetupTests;
 begin
   Test('a module exercising every index space validates',
@@ -1070,6 +1125,10 @@ begin
     TestFuncidxShorthandIntoANonNullableTable);
   Test('the implied-funcref expr form does not fit a (ref func) table',
     TestImpliedFuncrefExprFormIntoANonNullableTable);
+  Test('missing END before the next code entry is malformed',
+    TestMissingEndBeforeNextCodeEntry);
+  Test('END outside the declared code section is a size mismatch',
+    TestMissingEndConsumesNextSectionByte);
 
   Test('rejects a duplicate export name',
     TestRejectsDuplicateExportName);

--- a/source/units/Wasm.Wast.Runner.Test.pas
+++ b/source/units/Wasm.Wast.Runner.Test.pas
@@ -207,7 +207,12 @@ type
     procedure TestAssertMalformedTextNotMalformedFails;
     procedure TestAssertInvalidTextOperandPasses;
     procedure TestSimdTextModuleValidates;
-    procedure TestAssertUnlinkablePrechecksThenSkips;
+    procedure TestAssertUnlinkablePasses;
+    procedure TestAssertUnlinkableUnknownImportPasses;
+    procedure TestAssertUnlinkableWrongKindPasses;
+    procedure TestAssertUnlinkableWrongPrefixFails;
+    procedure TestAssertUnlinkableLinkableModuleFails;
+    procedure TestInlineModuleBodyRunsAsOneModule;
     procedure TestUnknownDirectiveSkipped;
     procedure TestExecutionCommandsSkipped;
     procedure TestAssertWithoutModuleOperandSkipped;
@@ -229,7 +234,15 @@ type
     procedure TestAssertExhaustion;
     procedure TestExternRefIdentityMatches;
     procedure TestExternRefIdentityMismatchFails;
+    procedure TestSpectestPrintFunctions;
+    procedure TestSpectestGlobals;
+    procedure TestSpectestTablesAndMemory;
+    procedure TestSpectestMemoryIsShared;
+    procedure TestRegisteredSpectestReplacesBuiltinWholeModule;
     procedure TestCrossModuleRegisterImport;
+    procedure TestModuleDefinitionDoesNotInstantiate;
+    procedure TestModuleInstancesAreGenerative;
+    procedure TestAnonymousModuleInstanceBecomesCurrent;
     procedure TestAssertTrapModuleOobSegmentPersists;
     procedure TestAssertTrapModuleTrappingStartPersists;
     procedure TestAssertTrapModuleNoTrapReportsFail;
@@ -556,17 +569,85 @@ begin
   Expect<string>(Item.Actual).ToBe('');
 end;
 
-procedure TWastRunnerTests.TestAssertUnlinkablePrechecksThenSkips;
+procedure TWastRunnerTests.TestAssertUnlinkablePasses;
 var
   Item: TWastCommandResult;
 begin
-  { assert_unlinkable pre-checks the operand (assemble + decode + validate),
-    which succeeds for this well-formed module, then skips because linkage is
-    not yet judgeable. A skip stays a skip; the failure path is what is new. }
+  Item := ResultAt(
+    '(module $m (func (export "f") (param i32)))' + sLineBreak
+    + '(register "m" $m)' + sLineBreak
+    + '(assert_unlinkable '
+    + '  (module (import "m" "f" (func (param i64))))'
+    + '  "incompatible import type")', 2);
+  Expect<string>(WastStatusName(Item.Status)).ToBe('pass');
+  Expect<string>(WastErrorKindName(Item.ActualKind)).ToBe('unlinkable');
+  ExpectStartsWith(Item.Actual, 'incompatible import type');
+end;
+
+procedure TWastRunnerTests.TestAssertUnlinkableUnknownImportPasses;
+var
+  Item: TWastCommandResult;
+begin
+  { A missing module/name is represented as WASM_NO_ADDR and handed to the
+    instantiator, which owns the `unknown import` link-error classification. }
   Item := FirstResult(
-    '(assert_unlinkable (module quote "(module)") "unknown import")');
-  Expect<string>(WastStatusName(Item.Status)).ToBe('skip');
-  Expect<string>(Item.Actual).ToBe(WAST_REASON_NEEDS_TIER);
+    '(assert_unlinkable (module (import "missing" "f" (func))) '
+    + '"unknown import")');
+  Expect<string>(WastStatusName(Item.Status)).ToBe('pass');
+  Expect<string>(WastErrorKindName(Item.ActualKind)).ToBe('unlinkable');
+  ExpectStartsWith(Item.Actual, 'unknown import');
+end;
+
+procedure TWastRunnerTests.TestAssertUnlinkableWrongKindPasses;
+var
+  Item: TWastCommandResult;
+begin
+  { A known export of the wrong external kind is incompatible, not absent. }
+  Item := ResultAt(
+    '(module $m (memory (export "x") 1))' + sLineBreak
+    + '(register "m" $m)' + sLineBreak
+    + '(assert_unlinkable (module (import "m" "x" (func))) '
+    + '"incompatible import type")', 2);
+  Expect<string>(WastStatusName(Item.Status)).ToBe('pass');
+  Expect<string>(WastErrorKindName(Item.ActualKind)).ToBe('unlinkable');
+  ExpectStartsWith(Item.Actual, 'incompatible import type');
+end;
+
+procedure TWastRunnerTests.TestAssertUnlinkableWrongPrefixFails;
+var
+  Item: TWastCommandResult;
+begin
+  Item := FirstResult(
+    '(assert_unlinkable (module (import "missing" "f" (func))) '
+    + '"incompatible import type")');
+  Expect<string>(WastStatusName(Item.Status)).ToBe('fail');
+  Expect<string>(WastErrorKindName(Item.ActualKind)).ToBe('unlinkable');
+  ExpectStartsWith(Item.Actual, 'unknown import');
+end;
+
+procedure TWastRunnerTests.TestAssertUnlinkableLinkableModuleFails;
+var
+  Item: TWastCommandResult;
+begin
+  Item := FirstResult(
+    '(assert_unlinkable (module) "unknown import")');
+  Expect<string>(WastStatusName(Item.Status)).ToBe('fail');
+  Expect<string>(WastErrorKindName(Item.ActualKind)).ToBe('none');
+  Expect<string>(Item.Actual).ToBe(WAST_NO_ERROR);
+end;
+
+procedure TWastRunnerTests.TestInlineModuleBodyRunsAsOneModule;
+var
+  Run: TWastRunResult;
+begin
+  Run := RunWastSource('(func) (memory 0) (func (export "f"))');
+  try
+    Expect<Integer>(Run.Count).ToBe(1);
+    Expect<string>(WastCommandKindName(Run[0].Kind)).ToBe('module');
+    Expect<string>(WastStatusName(Run[0].Status)).ToBe('pass');
+  finally
+    Run.Free;
+  end;
 end;
 
 procedure TWastRunnerTests.TestUnknownDirectiveSkipped;
@@ -584,10 +665,10 @@ end;
 
 procedure TWastRunnerTests.TestExecutionCommandsSkipped;
 begin
-  { With a tier landed but NO module instantiated in the script, every
-    action/assertion still skips — there is nothing to run it against. The
-    reasons now name the real gap (no instance, text-only, exceptions)
-    rather than a blanket "needs a tier". }
+  { With a tier landed but NO module instantiated in the script, actions
+    still skip because there is nothing to run against. assert_unlinkable is
+    self-contained: this empty operand links, so the assertion is judged and
+    fails because it expected an error. }
   Expect<string>(StatusSignature(
     '(register "m")' + sLineBreak +
     '(invoke "f" (i32.const 1))' + sLineBreak +
@@ -598,7 +679,7 @@ begin
     '(assert_exhaustion (invoke "f") "call stack exhausted")' + sLineBreak +
     '(assert_exception (invoke "f"))'))
     .ToBe('register:skip invoke:skip assert_return:skip assert_trap:skip '
-      + 'assert_unlinkable:skip assert_exhaustion:skip assert_exception:skip');
+      + 'assert_unlinkable:fail assert_exhaustion:skip assert_exception:skip');
 
   { No module precedes it, so there is no current instance to register. }
   Expect<string>(FirstResult('(register "m")').Actual)
@@ -842,6 +923,123 @@ begin
   Expect<string>(WastStatusName(Item.Status)).ToBe('fail');
 end;
 
+procedure TWastRunnerTests.TestSpectestPrintFunctions;
+begin
+  { The pinned reference host exports seven no-result diagnostic functions.
+    wasmlight keeps the harness quiet, but every exact signature must link and
+    execute as a no-op rather than causing the module and its actions to skip. }
+  Expect<string>(StatusSignature(
+    '(module' + sLineBreak
+    + '  (import "spectest" "print" (func $p))' + sLineBreak
+    + '  (import "spectest" "print_i32" (func $pi32 (param i32)))'
+    + sLineBreak
+    + '  (import "spectest" "print_i64" (func $pi64 (param i64)))'
+    + sLineBreak
+    + '  (import "spectest" "print_f32" (func $pf32 (param f32)))'
+    + sLineBreak
+    + '  (import "spectest" "print_f64" (func $pf64 (param f64)))'
+    + sLineBreak
+    + '  (import "spectest" "print_i32_f32"'
+    + '    (func $pi32f32 (param i32 f32)))' + sLineBreak
+    + '  (import "spectest" "print_f64_f64"'
+    + '    (func $pf64f64 (param f64 f64)))' + sLineBreak
+    + '  (func (export "run")' + sLineBreak
+    + '    (call $p)' + sLineBreak
+    + '    (call $pi32 (i32.const 1))' + sLineBreak
+    + '    (call $pi64 (i64.const 2))' + sLineBreak
+    + '    (call $pf32 (f32.const 3))' + sLineBreak
+    + '    (call $pf64 (f64.const 4))' + sLineBreak
+    + '    (call $pi32f32 (i32.const 5) (f32.const 6))' + sLineBreak
+    + '    (call $pf64f64 (f64.const 7) (f64.const 8))))' + sLineBreak
+    + '(invoke "run")'))
+    .ToBe('module:pass invoke:pass');
+end;
+
+procedure TWastRunnerTests.TestSpectestGlobals;
+begin
+  { Values and const mutability match interpreter/host/spectest.ml: integers
+    are 666 and floating-point globals are their nearest 666.6 value. }
+  Expect<string>(StatusSignature(
+    '(module' + sLineBreak
+    + '  (global (export "i32") (import "spectest" "global_i32") i32)'
+    + sLineBreak
+    + '  (global (export "i64") (import "spectest" "global_i64") i64)'
+    + sLineBreak
+    + '  (global (export "f32") (import "spectest" "global_f32") f32)'
+    + sLineBreak
+    + '  (global (export "f64") (import "spectest" "global_f64") f64))'
+    + sLineBreak
+    + '(assert_return (get "i32") (i32.const 666))' + sLineBreak
+    + '(assert_return (get "i64") (i64.const 666))' + sLineBreak
+    + '(assert_return (get "f32") (f32.const 666.6))' + sLineBreak
+    + '(assert_return (get "f64") (f64.const 666.6))'))
+    .ToBe('module:pass assert_return:pass assert_return:pass '
+      + 'assert_return:pass assert_return:pass');
+end;
+
+procedure TWastRunnerTests.TestSpectestTablesAndMemory;
+begin
+  { The standard externals preserve their address types and initial sizes:
+    i32/i64 tables both start at 10 entries; the i32 memory starts at 1 page. }
+  Expect<string>(StatusSignature(
+    '(module' + sLineBreak
+    + '  (table $t (import "spectest" "table") 10 20 funcref)'
+    + sLineBreak
+    + '  (table $t64 (import "spectest" "table64")'
+    + '    i64 10 20 funcref)' + sLineBreak
+    + '  (memory $m (import "spectest" "memory") 1 2)' + sLineBreak
+    + '  (func (export "ts") (result i32) (table.size $t))'
+    + sLineBreak
+    + '  (func (export "ts64") (result i64) (table.size $t64))'
+    + sLineBreak
+    + '  (func (export "ms") (result i32) (memory.size $m)))'
+    + sLineBreak
+    + '(assert_return (invoke "ts") (i32.const 10))' + sLineBreak
+    + '(assert_return (invoke "ts64") (i64.const 10))' + sLineBreak
+    + '(assert_return (invoke "ms") (i32.const 1))'))
+    .ToBe('module:pass assert_return:pass assert_return:pass '
+      + 'assert_return:pass');
+end;
+
+procedure TWastRunnerTests.TestSpectestMemoryIsShared;
+begin
+  { Per-script host state is shared: a store through one module's imported
+    memory is observable through a later module importing the same memory. }
+  Expect<string>(StatusSignature(
+    '(module' + sLineBreak
+    + '  (memory $m (import "spectest" "memory") 1 2)' + sLineBreak
+    + '  (func (export "put")'
+    + '    (i32.store8 (i32.const 7) (i32.const 42))))' + sLineBreak
+    + '(invoke "put")' + sLineBreak
+    + '(module' + sLineBreak
+    + '  (memory $m (import "spectest" "memory") 1 2)' + sLineBreak
+    + '  (func (export "get") (result i32)'
+    + '    (i32.load8_u (i32.const 7))))' + sLineBreak
+    + '(assert_return (invoke "get") (i32.const 42))'))
+    .ToBe('module:pass invoke:pass module:pass assert_return:pass');
+end;
+
+procedure TWastRunnerTests.TestRegisteredSpectestReplacesBuiltinWholeModule;
+const
+  Src =
+    '(module $replacement (func (export "print") (result i32) (i32.const 7)))'
+    + sLineBreak + '(register "spectest" $replacement)' + sLineBreak
+    + '(module (import "spectest" "print" (func $p (result i32)))'
+    + ' (func (export "call") (result i32) (call $p)))' + sLineBreak
+    + '(assert_return (invoke "call") (i32.const 7))';
+var
+  Run: TWastRunResult;
+begin
+  Run := RunWastSource(Src);
+  try
+    Expect<Integer>(Run.Count).ToBe(4);
+    Expect<string>(WastStatusName(Run[2].Status)).ToBe('pass');
+    Expect<string>(WastStatusName(Run[3].Status)).ToBe('pass');
+  finally
+    Run.Free;
+  end;
+end;
+
 procedure TWastRunnerTests.TestCrossModuleRegisterImport;
 begin
   { An exporter registered under "M", then an importer that imports
@@ -852,6 +1050,48 @@ begin
     + MODULE_IMPORTER + sLineBreak
     + '(assert_return (invoke "f") (i32.const 5))'))
     .ToBe('module:pass register:pass module:pass assert_return:pass');
+end;
+
+procedure TWastRunnerTests.TestModuleDefinitionDoesNotInstantiate;
+begin
+  { The maximum valid i32 memory is intentionally impractical to allocate.
+    Definition formation validates it but must not create store state. }
+  Expect<string>(StatusSignature(
+    '(module definition (memory 65536))' + sLineBreak
+    + '(module (func (export "ok") (result i32) (i32.const 1)))'
+      + sLineBreak
+    + '(assert_return (invoke "ok") (i32.const 1))'))
+    .ToBe('module:pass module:pass assert_return:pass');
+end;
+
+procedure TWastRunnerTests.TestModuleInstancesAreGenerative;
+const
+  DEFINITION =
+    '(module definition $M'
+    + ' (global $g (export "g") (mut i32) (i32.const 0))'
+    + ' (func (export "set") (global.set $g (i32.const 1))))';
+begin
+  { Both instances borrow one immutable definition but own distinct globals. }
+  Expect<string>(StatusSignature(
+    DEFINITION + sLineBreak
+    + '(module instance $I1 $M)' + sLineBreak
+    + '(module instance $I2 $M)' + sLineBreak
+    + '(invoke $I1 "set")' + sLineBreak
+    + '(assert_return (get $I1 "g") (i32.const 1))' + sLineBreak
+    + '(assert_return (get $I2 "g") (i32.const 0))'))
+    .ToBe('module:pass module:pass module:pass invoke:pass '
+      + 'assert_return:pass assert_return:pass');
+end;
+
+procedure TWastRunnerTests.TestAnonymousModuleInstanceBecomesCurrent;
+begin
+  Expect<string>(StatusSignature(
+    '(module definition $M'
+    + ' (func (export "seven") (result i32) (i32.const 7)))'
+      + sLineBreak
+    + '(module instance $M)' + sLineBreak
+    + '(assert_return (invoke "seven") (i32.const 7))'))
+    .ToBe('module:pass module:pass assert_return:pass');
 end;
 
 procedure TWastRunnerTests.TestAssertTrapModuleOobSegmentPersists;
@@ -1352,8 +1592,18 @@ begin
     TestAssertInvalidTextOperandPasses);
   Test('a vector mnemonic in a text module validates and passes',
     TestSimdTextModuleValidates);
-  Test('assert_unlinkable pre-checks the operand then skips',
-    TestAssertUnlinkablePrechecksThenSkips);
+  Test('assert_unlinkable passes on an incompatible import',
+    TestAssertUnlinkablePasses);
+  Test('assert_unlinkable passes on an unknown import',
+    TestAssertUnlinkableUnknownImportPasses);
+  Test('assert_unlinkable passes on a wrong-kind import',
+    TestAssertUnlinkableWrongKindPasses);
+  Test('assert_unlinkable reports a fail on a wrong prefix',
+    TestAssertUnlinkableWrongPrefixFails);
+  Test('assert_unlinkable reports a fail when linkage succeeds',
+    TestAssertUnlinkableLinkableModuleFails);
+  Test('an inline module body runs as one module',
+    TestInlineModuleBodyRunsAsOneModule);
   Test('unknown directive skipped', TestUnknownDirectiveSkipped);
   Test('execution commands skipped', TestExecutionCommandsSkipped);
   Test('assert without a module operand skipped',
@@ -1385,8 +1635,23 @@ begin
     TestExternRefIdentityMatches);
   Test('assert_return reports a fail on externref mismatch',
     TestExternRefIdentityMismatchFails);
+  Test('spectest print functions link and execute',
+    TestSpectestPrintFunctions);
+  Test('spectest globals carry the pinned values', TestSpectestGlobals);
+  Test('spectest tables and memory carry pinned limits',
+    TestSpectestTablesAndMemory);
+  Test('spectest memory is shared for the whole script',
+    TestSpectestMemoryIsShared);
+  Test('a registered spectest replaces the built-in whole module',
+    TestRegisteredSpectestReplacesBuiltinWholeModule);
   Test('register binds an instance for cross-module import',
     TestCrossModuleRegisterImport);
+  Test('module definition validates without instantiating',
+    TestModuleDefinitionDoesNotInstantiate);
+  Test('module instances are fresh and generative',
+    TestModuleInstancesAreGenerative);
+  Test('anonymous module instance becomes current',
+    TestAnonymousModuleInstanceBecomesCurrent);
   Test('assert_trap over a module judges an OOB segment and persists earlier',
     TestAssertTrapModuleOobSegmentPersists);
   Test('assert_trap over a module judges a trapping start and persists data',

--- a/source/units/Wasm.Wast.Runner.pas
+++ b/source/units/Wasm.Wast.Runner.pas
@@ -35,12 +35,12 @@
       function is run through the tier, so a trapping start is judged too.
       The trap message is prefix-matched like an action trap
 
-  Still SKIPPED, never silently a pass: `assert_unlinkable` (a pre-check
-  assembles+validates the operand — a false rejection there is a FAIL, §4 —
-  but linkage we cannot yet judge), an `assert_return`/`invoke` whose module
-  never instantiated, imports the harness cannot satisfy (no host `spectest`
-  module), and the `_custom` directives outside the reference grammar. A
-  skip is an honest "not judged".
+  Still SKIPPED, never silently a pass: an `assert_return`/`invoke` whose
+  module never instantiated, imports outside the standard `spectest` host
+  module and script registry, and the `_custom` directives outside the
+  reference grammar. `assert_unlinkable` is judged through the same resolver
+  and InstantiateModule path as a top-level module; only an EWasmLinkError
+  satisfies it. A skip is an honest "not judged".
 
   THE PER-SCRIPT LIFECYCLE. One engine and one store back a whole script,
   mirroring the reference interpreter's per-script state. Modules
@@ -93,16 +93,16 @@ const
     WAST_REASON_TEXT_FORMAT is gone (design §4, wave 6): text and quote
     modules now assemble through Wasm.Wat.Assembler and re-enter the shipped
     decode -> validate -> instantiate path, so a text module is no longer a
-    skip — it is judged, exactly like a binary one. What still skips are the
-    genuinely-unjudgeable cases below (no instance, unresolved host import,
-    linkage we cannot check without more plumbing). }
+    skip — it is judged, exactly like a binary one. The standard `spectest`
+    host and `assert_unlinkable` are now judged too. Remaining skip reasons are
+    retained for non-standard/custom directives and scripts that genuinely
+    have no usable instance. }
   WAST_REASON_NEEDS_TIER = 'needs an execution tier';
   WAST_REASON_UNKNOWN_DIRECTIVE = 'directive not in the reference grammar';
   WAST_REASON_NO_MODULE_OPERAND = 'no module operand';
 
-  { An action or assertion whose current module never instantiated — a text
-    module, or one whose imports could not be satisfied. Not a divergence,
-    just nothing to run it against. }
+  { An action or assertion whose current module never instantiated. Not a
+    divergence, just nothing to run it against. }
   WAST_REASON_NO_INSTANCE = 'no instantiated module';
   WAST_REASON_UNRESOLVED_IMPORT = 'import not provided by the harness';
   WAST_REASON_NO_EXPORT = 'no such export';
@@ -159,7 +159,8 @@ type
   TWastTierMode = (wtmInterp, wtmJit, wtmAot);
 
   { Which error class a module attempt produced. The hierarchy is
-    load-bearing (AGENTS.md): malformed and invalid are different answers.
+    load-bearing (AGENTS.md): malformed, invalid, and unlinkable are different
+    answers.
     wekText is a TEXT-format syntax error from the assembler — what
     `assert_malformed` over a text/quote module expects, kept apart from
     wekDecode so a decode error on the assembler's OWN output can be flagged
@@ -171,6 +172,7 @@ type
     wekDecode,
     wekValidation,
     wekText,
+    wekLink,
     wekOther
   );
 
@@ -348,6 +350,7 @@ begin
     wekDecode: Result := 'malformed';
     wekValidation: Result := 'invalid';
     wekText: Result := 'text';
+    wekLink: Result := 'unlinkable';
     wekOther: Result := 'internal';
   else
     Result := '?';
@@ -458,6 +461,26 @@ begin
       ADst := ADst + ')';
     end;
   end;
+end;
+
+{ Re-render `(module definition $id? fields...)` as the ordinary text-module
+  form the WAT assembler owns. `definition` is script syntax, not a module
+  declaration; the optional id is retained as the module's documentary id. }
+function RenderDefinitionBytes(const ANode: TWastNode): TWasmBytes;
+var
+  S: string;
+  I, J: Integer;
+begin
+  S := '(module';
+  for I := 2 to ANode.Count - 1 do
+  begin
+    S := S + ' ';
+    RenderNodeInto(ANode[I], S);
+  end;
+  S := S + ')';
+  SetLength(Result, Length(S));
+  for J := 1 to Length(S) do
+    Result[J - 1] := Byte(Ord(S[J]));
 end;
 
 function RenderNodeBytes(const ANode: TWastNode): TWasmBytes;
@@ -619,6 +642,8 @@ begin
   try
     if AForm = wmfQuote then
       ABytes := AssembleQuote(ModuleBinaryBytes(ANode))
+    else if (ANode.Count >= 2) and ANode[1].IsAtom('definition') then
+      ABytes := AssembleWat(RenderDefinitionBytes(ANode))
     else
       ABytes := AssembleWat(RenderNodeBytes(ANode));
     Result := wasOk;
@@ -671,6 +696,16 @@ type
     Instance: TWasmModuleInstance;
   end;
 
+  { A script-level module definition is validated but not instantiated. Its
+    IR and bytes are retained so every `(module instance ...)` can allocate a
+    fresh instance from the same immutable definition. }
+  TWastDefinition = record
+    Name: string;
+    Model: TWasmModule;
+    Ir: TWasmIrModule;
+    Bytes: TWasmBytes;
+  end;
+
   TWastHostRef = record
     Id: UInt32;
     Ref: TWasmRef;
@@ -686,7 +721,19 @@ type
     FCurrent: TWasmModuleInstance;   { last instantiated, nil if none }
     FNamed: array of TWastBinding;   { by $id (with the leading $) }
     FRegistry: array of TWastBinding;{ by register name }
+    FDefinitions: array of TWastDefinition; { by definition $id }
     FHostRefs: array of TWastHostRef;
+    { The reference interpreter's per-script `spectest` externals. These are
+      allocated once and shared by every module in the script, exactly like a
+      registered module's exports. Host functions are minted lazily per
+      importing engine functype; their identity is not observable. }
+    FSpectestTable: TWasmTableAddr;
+    FSpectestTable64: TWasmTableAddr;
+    FSpectestMemory: TWasmMemAddr;
+    FSpectestGlobalI32: TWasmGlobalAddr;
+    FSpectestGlobalI64: TWasmGlobalAddr;
+    FSpectestGlobalF32: TWasmGlobalAddr;
+    FSpectestGlobalF64: TWasmGlobalAddr;
     { Instances borrow these; they must outlive the store (ADR-0003). }
     FIrs: array of TWasmIrModule;
     FBuffers: array of TWasmBytes;
@@ -708,7 +755,10 @@ type
 
     function LookupNamed(const AId: string): TWasmModuleInstance;
     function LookupRegistry(const AName: string): TWasmModuleInstance;
+    function LookupDefinition(const AId: string): Integer;
     procedure BindNamed(const AId: string; const AInst: TWasmModuleInstance);
+    procedure BindDefinition(const AId: string; const AModel: TWasmModule;
+      const AIr: TWasmIrModule; const ABytes: TWasmBytes);
     procedure RegisterName(const AName: string;
       const AInst: TWasmModuleInstance);
     { Mint (once) and return a stable host box carrying identity AId, kept
@@ -729,6 +779,7 @@ type
       shows up as a lower loaded count). }
     procedure AotLoadInstance(const AInst: TWasmModuleInstance;
       const AIr: TWasmIrModule; const ABytes: TWasmBytes);
+    procedure InitSpectest;
 
     property Engine: TWasmEngine read FEngine;
     property Store: TWasmStore read FStore;
@@ -753,6 +804,7 @@ begin
   FCurrent := nil;
   FJit := nil;
   FCompiledCount := 0;
+  InitSpectest;
   { Register the JIT companion on the store (§4.1): it points the store's
     JitInvokeCompiled hook at the compiled-function dispatcher but leaves
     TierInvoke on the interpreter and compiles nothing until a function is
@@ -761,6 +813,42 @@ begin
     interpreter with the same tallies. }
   if FMode = wtmJit then
     FJit := RegisterJit(FStore);
+end;
+
+procedure SpectestPrint(const AStore: TWasmStore; const AData: Pointer;
+  const AParams: PWasmValue; const AResults: PWasmValue);
+begin
+  { The spec-tests host prints only for human diagnostics. The conformance
+    harness is intentionally quiet; the function has no results or side
+    effects visible to wasm, so a no-op is observationally equivalent. }
+end;
+
+procedure TWastRunner.InitSpectest;
+var
+  TableType: TWasmTableType;
+  MemType: TWasmMemType;
+begin
+  { Pinned reference host: interpreter/host/spectest.ml at the matching spec
+    revision. Tables are 10..20 nullable funcref (one per address type), the
+    memory is 1..2 i32 pages, and immutable numeric globals carry 666/666.6. }
+  TableType := MakeTableType(
+    MakeRefType(True, MakeAbsHeapType(wahFunc)),
+    MakeLimitsWithMax(watI32, 10, 20));
+  FSpectestTable := FStore.AddTable(TableType, WASM_REF_NULL);
+  TableType.Limits.AddrType := watI64;
+  FSpectestTable64 := FStore.AddTable(TableType, WASM_REF_NULL);
+
+  MemType := MakeMemType(MakeLimitsWithMax(watI32, 1, 2));
+  FSpectestMemory := FStore.AddMemory(MemType);
+
+  FSpectestGlobalI32 := FStore.AddGlobal(
+    MakeGlobalType(False, MakeNumValueType(wntI32)), MakeValueI32(666));
+  FSpectestGlobalI64 := FStore.AddGlobal(
+    MakeGlobalType(False, MakeNumValueType(wntI64)), MakeValueI64(666));
+  FSpectestGlobalF32 := FStore.AddGlobal(
+    MakeGlobalType(False, MakeNumValueType(wntF32)), MakeValueF32(666.6));
+  FSpectestGlobalF64 := FStore.AddGlobal(
+    MakeGlobalType(False, MakeNumValueType(wntF64)), MakeValueF64(666.6));
 end;
 
 destructor TWastRunner.Destroy;
@@ -777,6 +865,11 @@ begin
     FAotJits[I].Free;
   FStore.Free;
   FEngine.Free;
+  for I := 0 to High(FDefinitions) do
+  begin
+    FDefinitions[I].Ir.Free;
+    FDefinitions[I].Model.Free;
+  end;
   for I := 0 to High(FIrs) do
     FIrs[I].Free;
   FModel.Free;
@@ -888,12 +981,36 @@ begin
       Exit(FRegistry[I].Instance);
 end;
 
+function TWastRunner.LookupDefinition(const AId: string): Integer;
+var
+  I: Integer;
+begin
+  Result := -1;
+  for I := High(FDefinitions) downto 0 do
+    if FDefinitions[I].Name = AId then
+      Exit(I);
+end;
+
 procedure TWastRunner.BindNamed(const AId: string;
   const AInst: TWasmModuleInstance);
 begin
   SetLength(FNamed, Length(FNamed) + 1);
   FNamed[High(FNamed)].Name := AId;
   FNamed[High(FNamed)].Instance := AInst;
+end;
+
+procedure TWastRunner.BindDefinition(const AId: string;
+  const AModel: TWasmModule; const AIr: TWasmIrModule;
+  const ABytes: TWasmBytes);
+var
+  Index: Integer;
+begin
+  Index := Length(FDefinitions);
+  SetLength(FDefinitions, Index + 1);
+  FDefinitions[Index].Name := AId;
+  FDefinitions[Index].Model := AModel;
+  FDefinitions[Index].Ir := AIr;
+  FDefinitions[Index].Bytes := ABytes;
 end;
 
 procedure TWastRunner.RegisterName(const AName: string;
@@ -1217,68 +1334,232 @@ end;
 
 { --- import resolution --------------------------------------------------- }
 
-{ Build the import addresses AModel needs from the registry, in index-space
-  order per kind. Returns False (with AWhy) when any import cannot be
-  satisfied — the harness provides no host `spectest` module, so those
-  modules are skipped rather than failed. }
-function ResolveImports(const ARunner: TWastRunner; const AModel: TWasmModule;
-  out AImports: TWasmImports; out AWhy: string): Boolean;
+type
+  TSpectestImportStatus = (
+    sisNotSpectest,
+    sisResolved,
+    sisUnknown,
+    sisIncompatible
+  );
+
+function FuncTypeIs(const AType: TWasmFuncType;
+  const AParams: array of TWasmNumType): Boolean;
 var
+  I: Integer;
+begin
+  if (Length(AType.Params) <> Length(AParams)) or
+    (Length(AType.Results) <> 0) then
+    Exit(False);
+  for I := 0 to High(AParams) do
+    if (AType.Params[I].Kind <> wvkNum) or
+      (AType.Params[I].Num <> AParams[I]) then
+      Exit(False);
+  Result := True;
+end;
+
+{ Resolve one import from the standard host module in the pinned reference
+  interpreter. The declared function type has already been interned into
+  engine space; using that exact id for the host function keeps import
+  matching nominal while the explicit signature check rejects a misspelled
+  spectest contract. }
+function ResolveSpectestImport(const ARunner: TWastRunner;
+  const AImp: TWasmImport; const ATypeIds: TWasmEngineTypeIds;
+  out AAddr: UInt32): TSpectestImportStatus;
+var
+  ExpectedKind: TWasmExternKind;
+  ExpectedId: TWasmEngineTypeId;
+  FuncType: TWasmFuncType;
+  SignatureOk: Boolean;
+begin
+  AAddr := WASM_NO_ADDR;
+  if AImp.ModuleName <> 'spectest' then
+    Exit(sisNotSpectest);
+
+  SignatureOk := True;
+  if AImp.Name = 'print' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'print_i32' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'print_i64' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'print_f32' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'print_f64' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'print_i32_f32' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'print_f64_f64' then
+    ExpectedKind := wxkFunc
+  else if AImp.Name = 'global_i32' then
+    ExpectedKind := wxkGlobal
+  else if AImp.Name = 'global_i64' then
+    ExpectedKind := wxkGlobal
+  else if AImp.Name = 'global_f32' then
+    ExpectedKind := wxkGlobal
+  else if AImp.Name = 'global_f64' then
+    ExpectedKind := wxkGlobal
+  else if AImp.Name = 'table' then
+    ExpectedKind := wxkTable
+  else if AImp.Name = 'table64' then
+    ExpectedKind := wxkTable
+  else if AImp.Name = 'memory' then
+    ExpectedKind := wxkMem
+  else
+    Exit(sisUnknown);
+
+  if AImp.Kind <> ExpectedKind then
+    Exit(sisIncompatible);
+
+  case ExpectedKind of
+    wxkFunc:
+      begin
+        if AImp.FuncTypeIndex >= UInt32(Length(ATypeIds)) then
+          Exit(sisIncompatible);
+        ExpectedId := ATypeIds[AImp.FuncTypeIndex];
+        FuncType := ARunner.Engine.EngineType(ExpectedId).Comp.Func;
+        if AImp.Name = 'print' then
+          SignatureOk := FuncTypeIs(FuncType, [])
+        else if AImp.Name = 'print_i32' then
+          SignatureOk := FuncTypeIs(FuncType, [wntI32])
+        else if AImp.Name = 'print_i64' then
+          SignatureOk := FuncTypeIs(FuncType, [wntI64])
+        else if AImp.Name = 'print_f32' then
+          SignatureOk := FuncTypeIs(FuncType, [wntF32])
+        else if AImp.Name = 'print_f64' then
+          SignatureOk := FuncTypeIs(FuncType, [wntF64])
+        else if AImp.Name = 'print_i32_f32' then
+          SignatureOk := FuncTypeIs(FuncType, [wntI32, wntF32])
+        else if AImp.Name = 'print_f64_f64' then
+          SignatureOk := FuncTypeIs(FuncType, [wntF64, wntF64]);
+        if not SignatureOk then
+          Exit(sisIncompatible);
+        AAddr := ARunner.Store.AddHostFunc(ExpectedId, @SpectestPrint, nil);
+      end;
+    wxkTable:
+      if AImp.Name = 'table64' then
+        AAddr := ARunner.FSpectestTable64
+      else
+        AAddr := ARunner.FSpectestTable;
+    wxkMem:
+      AAddr := ARunner.FSpectestMemory;
+    wxkGlobal:
+      if AImp.Name = 'global_i32' then
+        AAddr := ARunner.FSpectestGlobalI32
+      else if AImp.Name = 'global_i64' then
+        AAddr := ARunner.FSpectestGlobalI64
+      else if AImp.Name = 'global_f32' then
+        AAddr := ARunner.FSpectestGlobalF32
+      else
+        AAddr := ARunner.FSpectestGlobalF64;
+  end;
+  Result := sisResolved;
+end;
+
+procedure AppendImportAddr(var AImports: TWasmImports;
+  const AKind: TWasmExternKind; const AAddr: UInt32);
+begin
+  case AKind of
+    wxkFunc:
+      begin
+        SetLength(AImports.Funcs, Length(AImports.Funcs) + 1);
+        AImports.Funcs[High(AImports.Funcs)] := AAddr;
+      end;
+    wxkTable:
+      begin
+        SetLength(AImports.Tables, Length(AImports.Tables) + 1);
+        AImports.Tables[High(AImports.Tables)] := AAddr;
+      end;
+    wxkMem:
+      begin
+        SetLength(AImports.Mems, Length(AImports.Mems) + 1);
+        AImports.Mems[High(AImports.Mems)] := AAddr;
+      end;
+    wxkGlobal:
+      begin
+        SetLength(AImports.Globals, Length(AImports.Globals) + 1);
+        AImports.Globals[High(AImports.Globals)] := AAddr;
+      end;
+    wxkTag:
+      begin
+        SetLength(AImports.Tags, Length(AImports.Tags) + 1);
+        AImports.Tags[High(AImports.Tags)] := AAddr;
+      end;
+  end;
+end;
+
+{ Build the import addresses AModel needs from the script registry and the
+  pinned standard `spectest` host module, in index-space order per kind.
+  AAllowMissing is used by assert_unlinkable: a genuinely absent export is
+  represented by WASM_NO_ADDR so instantiation judges it as `unknown import`.
+  A known export of the wrong kind remains an incompatible-import result. }
+function ResolveImports(const ARunner: TWastRunner; const AModel: TWasmModule;
+  const AIr: TWasmIrModule; out AImports: TWasmImports; out AWhy: string;
+  const AAllowMissing: Boolean = False): Boolean;
+var
+  CanonIds, TypeIds: TWasmEngineTypeIds;
   I: Integer;
   Imp: TWasmImport;
   Exporter: TWasmModuleInstance;
   Kind: TWasmExternKind;
   Addr: UInt32;
+  SpectestStatus: TSpectestImportStatus;
 begin
   Result := False;
+  AWhy := '';
   AImports.Funcs := nil;
   AImports.Tables := nil;
   AImports.Mems := nil;
   AImports.Globals := nil;
   AImports.Tags := nil;
+  ARunner.Engine.InternModule(AIr, CanonIds, TypeIds);
   for I := 0 to AModel.ImportCount - 1 do
   begin
     Imp := AModel.Imports[I];
+    { A script registration is a whole-module binding and is last-definition
+      wins. In particular, `(register "spectest" ...)` replaces the standard
+      host; never splice some names from that instance and others from the
+      built-in module. }
     Exporter := ARunner.LookupRegistry(Imp.ModuleName);
     if Exporter = nil then
     begin
+      SpectestStatus := ResolveSpectestImport(ARunner, Imp, TypeIds, Addr);
+      if SpectestStatus = sisResolved then
+      begin
+        AppendImportAddr(AImports, Imp.Kind, Addr);
+        Continue;
+      end;
+      if SpectestStatus = sisIncompatible then
+      begin
+        AWhy := string(MSG_LINK_INCOMPATIBLE_IMPORT);
+        Exit;
+      end;
+    end;
+    if Exporter = nil then
+    begin
+      if AAllowMissing then
+      begin
+        AppendImportAddr(AImports, Imp.Kind, WASM_NO_ADDR);
+        Continue;
+      end;
       AWhy := Format('%s: "%s"."%s"', [WAST_REASON_UNRESOLVED_IMPORT,
         Imp.ModuleName, Imp.Name]);
       Exit;
     end;
     if not Exporter.FindExport(Imp.Name, Kind, Addr) or (Kind <> Imp.Kind) then
     begin
+      if AAllowMissing and (not Exporter.FindExport(Imp.Name, Kind, Addr)) then
+      begin
+        AppendImportAddr(AImports, Imp.Kind, WASM_NO_ADDR);
+        Continue;
+      end;
+      if AAllowMissing then
+        AWhy := string(MSG_LINK_INCOMPATIBLE_IMPORT)
+      else
       AWhy := Format('%s: "%s"."%s"', [WAST_REASON_UNRESOLVED_IMPORT,
         Imp.ModuleName, Imp.Name]);
       Exit;
     end;
-    case Imp.Kind of
-      wxkFunc:
-        begin
-          SetLength(AImports.Funcs, Length(AImports.Funcs) + 1);
-          AImports.Funcs[High(AImports.Funcs)] := Addr;
-        end;
-      wxkTable:
-        begin
-          SetLength(AImports.Tables, Length(AImports.Tables) + 1);
-          AImports.Tables[High(AImports.Tables)] := Addr;
-        end;
-      wxkMem:
-        begin
-          SetLength(AImports.Mems, Length(AImports.Mems) + 1);
-          AImports.Mems[High(AImports.Mems)] := Addr;
-        end;
-      wxkGlobal:
-        begin
-          SetLength(AImports.Globals, Length(AImports.Globals) + 1);
-          AImports.Globals[High(AImports.Globals)] := Addr;
-        end;
-      wxkTag:
-        begin
-          SetLength(AImports.Tags, Length(AImports.Tags) + 1);
-          AImports.Tags[High(AImports.Tags)] := Addr;
-        end;
-    end;
+    AppendImportAddr(AImports, Imp.Kind, Addr);
   end;
   Result := True;
 end;
@@ -1291,6 +1572,47 @@ begin
   if (ANode.Count >= 2) and (ANode[1].Kind = wnkAtom)
     and (Length(ANode[1].Atom) > 0) and (ANode[1].Atom[1] = '$') then
     Result := ANode[1].Atom;
+end;
+
+function IsModuleDefinition(const ANode: TWastNode): Boolean;
+begin
+  Result := (ANode.Count >= 2) and ANode[1].IsAtom('definition');
+end;
+
+function IsModuleInstance(const ANode: TWastNode): Boolean;
+begin
+  Result := (ANode.Count >= 2) and ANode[1].IsAtom('instance');
+end;
+
+function DefinitionId(const ANode: TWastNode): string;
+begin
+  Result := '';
+  if (ANode.Count >= 3) and (ANode[2].Kind = wnkAtom)
+    and (Length(ANode[2].Atom) > 0) and (ANode[2].Atom[1] = '$') then
+    Result := ANode[2].Atom;
+end;
+
+{ `(module instance $instance? $definition)`: with two ids the first names
+  the fresh instance; with one id it identifies the definition and leaves the
+  instance anonymous. }
+function InstanceIds(const ANode: TWastNode; out AInstanceId,
+  ADefinitionId: string): Boolean;
+begin
+  Result := False;
+  AInstanceId := '';
+  ADefinitionId := '';
+  if (ANode.Count = 3) and (ANode[2].Kind = wnkAtom) then
+    ADefinitionId := ANode[2].Atom
+  else if (ANode.Count = 4) and (ANode[2].Kind = wnkAtom)
+    and (ANode[3].Kind = wnkAtom) then
+  begin
+    AInstanceId := ANode[2].Atom;
+    ADefinitionId := ANode[3].Atom;
+  end
+  else
+    Exit;
+  Result := (Length(ADefinitionId) > 0) and (ADefinitionId[1] = '$')
+    and ((AInstanceId = '') or (AInstanceId[1] = '$'));
 end;
 
 { --- command execution --------------------------------------------------- }
@@ -1314,7 +1636,8 @@ end;
 function PrepareModule(const ARunner: TWastRunner; const ANode: TWastNode;
   const AForm: TWastModuleForm; var AResult: TWastCommandResult;
   out AIr: TWasmIrModule; out ABytes: TWasmBytes;
-  out AImports: TWasmImports): Boolean;
+  out AImports: TWasmImports;
+  const AAllowMissing: Boolean = False): Boolean;
 var
   Bytes: TWasmBytes;
   Ir: TWasmIrModule;
@@ -1390,7 +1713,8 @@ begin
     end;
   end;
 
-  if not ResolveImports(ARunner, ARunner.Model, AImports, Why) then
+  if not ResolveImports(ARunner, ARunner.Model, Ir, AImports, Why,
+    AAllowMissing) then
   begin
     Skipped(AResult, Why);
     Ir.Free;
@@ -1407,6 +1731,159 @@ begin
   Result := True;
 end;
 
+{ Validate a script-level module definition without instantiating it. A named
+  definition retains its decoded model, IR, and bytes for later generative
+  instantiation; an anonymous definition releases them after this command.
+  Imports are deliberately not resolved here: definition formation is a
+  decode/validation operation, while each instance links against the registry
+  state visible at its own command. }
+procedure RunModuleDefinition(const ARunner: TWastRunner;
+  const ACommand: TWastCommand; var AResult: TWastCommandResult);
+var
+  Bytes: TWasmBytes;
+  Ir: TWasmIrModule;
+  Model: TWasmModule;
+  Msg, Id: string;
+  Assembled: Boolean;
+begin
+  Ir := nil;
+  Model := nil;
+  Assembled := ACommand.ModuleForm <> wmfBinary;
+  if Assembled then
+  begin
+    case AssembleOperand(ACommand.Node, ACommand.ModuleForm, Bytes, Msg) of
+      wasTextError:
+        begin
+          AResult.ActualKind := wekText;
+          AResult.Actual := Msg;
+          AResult.Status := wrsFail;
+          Exit;
+        end;
+      wasInternal:
+        begin
+          AResult.ActualKind := wekOther;
+          AResult.Actual := Msg;
+          AResult.Status := wrsFail;
+          Exit;
+        end;
+    end;
+  end
+  else
+    Bytes := ModuleBinaryBytes(ACommand.Node);
+
+  try
+    Model := TWasmModule.Create;
+    DecodeModule(Bytes, Model);
+    Ir := ValidateModule(Model, Bytes);
+  except
+    on E: EWasmDecodeError do
+    begin
+      if Assembled then
+      begin
+        AResult.ActualKind := wekOther;
+        AResult.Actual := 'internal: assembler output failed to decode: '
+          + E.Message;
+      end
+      else
+      begin
+        AResult.ActualKind := wekDecode;
+        AResult.Actual := E.Message;
+      end;
+      AResult.Status := wrsFail;
+      Ir.Free;
+      Model.Free;
+      Exit;
+    end;
+    on E: EWasmValidationError do
+    begin
+      AResult.ActualKind := wekValidation;
+      AResult.Actual := E.Message;
+      AResult.Status := wrsFail;
+      Ir.Free;
+      Model.Free;
+      Exit;
+    end;
+    on E: Exception do
+    begin
+      AResult.ActualKind := wekOther;
+      AResult.Actual := E.ClassName + ': ' + E.Message;
+      AResult.Status := wrsFail;
+      Ir.Free;
+      Model.Free;
+      Exit;
+    end;
+  end;
+
+  Id := DefinitionId(ACommand.Node);
+  if Id <> '' then
+    ARunner.BindDefinition(Id, Model, Ir, Bytes)
+  else
+  begin
+    Ir.Free;
+    Model.Free;
+  end;
+  AResult.Status := wrsPass;
+end;
+
+{ Instantiate a retained definition afresh. The retained definition is
+  immutable; only its store-side state is allocated anew, so repeated instance
+  commands are generative while imports remain shared by address. }
+procedure RunModuleInstance(const ARunner: TWastRunner;
+  const ACommand: TWastCommand; var AResult: TWastCommandResult);
+var
+  InstanceId, DefId, Why: string;
+  DefIndex: Integer;
+  Def: TWastDefinition;
+  Imports: TWasmImports;
+  Inst: TWasmModuleInstance;
+begin
+  ARunner.Current := nil;
+  if not InstanceIds(ACommand.Node, InstanceId, DefId) then
+  begin
+    AResult.ActualKind := wekText;
+    AResult.Actual := 'malformed module instance command';
+    AResult.Status := wrsFail;
+    Exit;
+  end;
+  DefIndex := ARunner.LookupDefinition(DefId);
+  if DefIndex < 0 then
+  begin
+    AResult.ActualKind := wekText;
+    AResult.Actual := 'unknown module definition ' + DefId;
+    AResult.Status := wrsFail;
+    Exit;
+  end;
+  Def := ARunner.FDefinitions[DefIndex];
+  if not ResolveImports(ARunner, Def.Model, Def.Ir, Imports, Why) then
+  begin
+    Skipped(AResult, Why);
+    Exit;
+  end;
+  try
+    Inst := InstantiateModule(ARunner.Store, Def.Ir, @Def.Bytes[0],
+      NativeUInt(Length(Def.Bytes)), Imports);
+    ARunner.Store.RunPendingStart(Inst);
+  except
+    on E: EWasmLinkError do
+    begin
+      Skipped(AResult, WAST_REASON_UNRESOLVED_IMPORT + ': ' + E.Message);
+      Exit;
+    end;
+    on E: EWasmError do
+    begin
+      AResult.Actual := E.ClassName + ': ' + E.Message;
+      AResult.Status := wrsFail;
+      Exit;
+    end;
+  end;
+  ARunner.Current := Inst;
+  if InstanceId <> '' then
+    ARunner.BindNamed(InstanceId, Inst);
+  ARunner.ForceCompileInstance(Inst);
+  ARunner.AotLoadInstance(Inst, Def.Ir, Def.Bytes);
+  AResult.Status := wrsPass;
+end;
+
 { Decode, validate, instantiate, and run the start function of a top-level
   module. The IR and bytes are retained so the instance can borrow them for
   the life of the script. }
@@ -1419,6 +1896,17 @@ var
   Inst: TWasmModuleInstance;
   Id: string;
 begin
+  if IsModuleDefinition(ACommand.Node) then
+  begin
+    RunModuleDefinition(ARunner, ACommand, AResult);
+    Exit;
+  end;
+  if IsModuleInstance(ACommand.Node) then
+  begin
+    RunModuleInstance(ARunner, ACommand, AResult);
+    Exit;
+  end;
+
   { A module that fails to build leaves no instance — clear Current so later
     actions skip honestly rather than run against a stale module. }
   ARunner.Current := nil;
@@ -1592,35 +2080,27 @@ begin
   AResult.Status := wrsFail;
 end;
 
-{ `assert_unlinkable` over a MODULE operand: the module is well-formed and
-  valid by construction, so it is assembled, decoded, and validated as a
-  PRE-CHECK (a failure there is a false rejection — INV-2 — or a real decoder/
-  validator bug on a newly-reachable module, and is reported). When the
-  pre-check passes, the command still SKIPS: judging linkage needs plumbing
-  this wave does not add, and a skip stays a skip (§4). }
-procedure RunModulePrecheck(const ARunner: TWastRunner;
-  const AOperand: TWastNode; var AResult: TWastCommandResult);
-var
-  Kind: TWastErrorKind;
-  Msg: string;
+{ Finish an `assert_unlinkable` verdict from the EWasmLinkError message. The
+  script's expected string is a PREFIX, exactly like malformed, invalid, and
+  trap assertions. }
+procedure JudgeLinkError(const AMsg: string;
+  var AResult: TWastCommandResult);
 begin
-  Kind := AttemptOperand(ARunner.Model, AOperand,
-    DetectWastModuleForm(AOperand), Msg);
-  if Kind = wekNone then
-  begin
-    { Assembled, decoded, validated — we simply cannot judge the rest. }
-    Skipped(AResult, WAST_REASON_NEEDS_TIER);
-    Exit;
-  end;
-  AResult.ActualKind := Kind;
-  AResult.Actual := Msg;
-  AResult.Status := wrsFail;
+  AResult.ActualKind := wekLink;
+  AResult.Actual := AMsg;
+  if WastMessageMatches(AResult.Expected, AMsg) then
+    AResult.Status := wrsPass
+  else
+    AResult.Status := wrsFail;
 end;
 
 procedure RunAssertUnlinkable(const ARunner: TWastRunner;
   const ACommand: TWastCommand; var AResult: TWastCommandResult);
 var
   Operand: TWastNode;
+  Ir: TWasmIrModule;
+  Bytes: TWasmBytes;
+  Imports: TWasmImports;
 begin
   Operand := FindModuleOperand(ACommand.Node);
   if Operand = nil then
@@ -1629,7 +2109,47 @@ begin
     Exit;
   end;
   AResult.Expected := ExpectedFailure(ACommand.Node);
-  RunModulePrecheck(ARunner, Operand, AResult);
+
+  { The operand must first assemble, decode, and validate. PrepareModule also
+    resolves every available import, but in this arm deliberately preserves a
+    missing import as WASM_NO_ADDR so the shipped instantiator — the one link
+    authority — produces EWasmLinkError. A resolver-detected kind mismatch is
+    already a link error and is returned as the skipped-shaped resolution
+    result; promote it to a judged verdict here. }
+  if not PrepareModule(ARunner, Operand, DetectWastModuleForm(Operand),
+    AResult, Ir, Bytes, Imports, True) then
+  begin
+    if AResult.Status = wrsSkip then
+      JudgeLinkError(AResult.Actual, AResult);
+    Exit;
+  end;
+
+  try
+    InstantiateModule(ARunner.Store, Ir, @Bytes[0],
+      NativeUInt(Length(Bytes)), Imports);
+  except
+    on E: EWasmLinkError do
+    begin
+      JudgeLinkError(E.Message, AResult);
+      Exit;
+    end;
+    on E: EWasmError do
+    begin
+      { A trap, resource failure, or internal error is not an unlinkable
+        module. Keep the specific failure visible instead of mis-scoring it. }
+      ARunner.Store.Heap.ResetFrames;
+      ResetInterpContext(ARunner.Store);
+      AResult.ActualKind := wekOther;
+      AResult.Actual := E.ClassName + ': ' + E.Message;
+      AResult.Status := wrsFail;
+      Exit;
+    end;
+  end;
+
+  { Instantiation succeeded where a link error was required. }
+  AResult.ActualKind := wekNone;
+  AResult.Actual := WAST_NO_ERROR;
+  AResult.Status := wrsFail;
 end;
 
 { Resolve the expected reference identity a matcher compares against —
@@ -2064,6 +2584,32 @@ begin
   end;
 end;
 
+function IsModuleFieldHead(const AHead: string): Boolean;
+begin
+  Result := (AHead = 'type') or (AHead = 'rec') or (AHead = 'import')
+    or (AHead = 'func') or (AHead = 'table') or (AHead = 'memory')
+    or (AHead = 'global') or (AHead = 'export') or (AHead = 'start')
+    or (AHead = 'elem') or (AHead = 'data') or (AHead = 'tag');
+end;
+
+{ The reference tools also accept a text module written as a sequence of
+  module fields with the outer `(module ...)` elided. `inline-module.wast` in
+  the pinned core corpus is exactly this form. It is one module, not a script
+  containing several unknown directives, so detect the shape structurally and
+  feed the same WAT assembler by restoring only the omitted wrapper. }
+function IsInlineModuleBody(const AScript: TWastScript): Boolean;
+var
+  I: Integer;
+begin
+  if AScript.Count = 0 then
+    Exit(False);
+  for I := 0 to AScript.Count - 1 do
+    if (AScript[I].Kind <> wcUnknown)
+      or not IsModuleFieldHead(AScript[I].Node.HeadAtom) then
+      Exit(False);
+  Result := True;
+end;
+
 function RunWastSource(const ASource: string): TWastRunResult;
 begin
   Result := RunWastSource(ASource, wtmInterp);
@@ -2076,6 +2622,11 @@ var
 begin
   Script := ParseWastScript(ASource);
   try
+    if IsInlineModuleBody(Script) then
+    begin
+      FreeAndNil(Script);
+      Script := ParseWastScript('(module ' + ASource + sLineBreak + ')');
+    end;
     Result := RunWastScript(Script, AMode);
   finally
     Script.Free;

--- a/source/units/Wasm.Wast.Test.pas
+++ b/source/units/Wasm.Wast.Test.pas
@@ -69,6 +69,7 @@ type
     procedure TestRealisticScript;
     procedure TestModuleBinaryFormKeepsExactBytes;
     procedure TestModuleQuoteFormWithId;
+    procedure TestModuleDefinitionForms;
     procedure TestNestedModuleFormDetection;
     procedure TestUnknownDirectiveTolerated;
     procedure TestUnbalancedParensRejected;
@@ -414,6 +415,29 @@ begin
   end;
 end;
 
+procedure TWastTests.TestModuleDefinitionForms;
+var
+  Script: TWastScript;
+begin
+  Script := ParseWastScript(
+    '(module definition $text (func))' + sLineBreak
+    + '(module definition $bin binary "\00asm\01\00\00\00")' + sLineBreak
+    + '(module definition quote "(module)")');
+  try
+    Expect<Integer>(Script.Count).ToBe(3);
+    Expect<Boolean>(Script[0].Kind = wcModule).ToBe(True);
+    Expect<Boolean>(Script[0].ModuleForm = wmfText).ToBe(True);
+    Expect<Boolean>(Script[1].ModuleForm = wmfBinary).ToBe(True);
+    Expect<Boolean>(Script[2].ModuleForm = wmfQuote).ToBe(True);
+    { Classification is lazy: `definition`, its optional id, and the
+      payload remain available to the runner. }
+    Expect<string>(Script[0].Node[1].Atom).ToBe('definition');
+    Expect<string>(Script[0].Node[2].Atom).ToBe('$text');
+  finally
+    Script.Free;
+  end;
+end;
+
 procedure TWastTests.TestNestedModuleFormDetection;
 var
   Script: TWastScript;
@@ -557,6 +581,7 @@ begin
   Test('module binary form keeps exact bytes',
     TestModuleBinaryFormKeepsExactBytes);
   Test('module quote form with id', TestModuleQuoteFormWithId);
+  Test('module definition forms are detected', TestModuleDefinitionForms);
   Test('nested module form detection', TestNestedModuleFormDetection);
   Test('unknown directive tolerated', TestUnknownDirectiveTolerated);
   Test('unbalanced parens rejected', TestUnbalancedParensRejected);

--- a/source/units/Wasm.Wast.pas
+++ b/source/units/Wasm.Wast.pas
@@ -783,15 +783,18 @@ begin
 end;
 
 { (module quote "..."*) and (module binary "..."*), each optionally with
-  an id: the form marker is the atom right after `module` or after the
-  `$id`. A text module's elements there are lists — `(func ...)` and
-  friends — so a bare `binary` / `quote` atom is unambiguous. }
+  an id. A module definition inserts the literal `definition` before that
+  same optional id and form marker. A text module's elements there are lists
+  — `(func ...)` and friends — so a bare `binary` / `quote` atom remains
+  unambiguous in both command forms. }
 function DetectWastModuleForm(const ANode: TWastNode): TWastModuleForm;
 var
   Index: Integer;
 begin
   Result := wmfText;
   Index := 1;
+  if (Index < ANode.Count) and ANode[Index].IsAtom('definition') then
+    Inc(Index);
   if (Index < ANode.Count) and (ANode[Index].Kind = wnkAtom)
     and (Length(ANode[Index].Atom) > 0)
     and (ANode[Index].Atom[1] = '$') then

--- a/tests/spec/README.md
+++ b/tests/spec/README.md
@@ -110,6 +110,10 @@ path a binary module takes:
 
 - `(module ...)` / `(module quote ...)` / `(module binary ...)` at top level —
   assemble (text/quote), decode, validate, **instantiate**, run any start function
+- an inline sequence of module fields with the outer `(module ...)` elided —
+  assemble and run as one module, matching `inline-module.wast`
+- `(module definition ...)` / `(module instance ...)` — retain a validated
+  definition and instantiate fresh, generative instances against the registry
 - `(assert_malformed (module ...) "...")` — a TEXT/quote operand must raise
   `EWasmTextError` from the assembler; a BINARY operand must raise
   `EWasmDecodeError`. A decode error on the assembler's OWN output is an
@@ -125,15 +129,18 @@ path a binary module takes:
   the instantiation-trap form: the module is built and instantiated for real,
   an out-of-bounds active segment traps after earlier ones persist, and a
   trapping start function is judged
+- `(assert_unlinkable (module ...) "...")` — instantiate through the real
+  resolver and require a prefix-matching `EWasmLinkError`
+- imports from `spectest` — resolve the pinned standard print functions,
+  numeric globals, i32/i64 tables, and memory shared for the script lifetime
 
 Everything else is `SKIP` with a reason, never a silent pass:
 
 | Reason | Applies to |
 | --- | --- |
-| `no instantiated module` | An `assert_return` / `invoke` whose module did not instantiate — now mostly modules downstream of an unprovided import |
-| `needs an execution tier` | An action whose module the assembler cannot yet build for another reason |
-| `import not provided by the harness` | A module importing something the harness does not supply |
-| `assert_unlinkable` | Linkage is not yet judged (the operand is still assembled and validated as a pre-check) |
+| `no instantiated module` | An action downstream of a module that did not instantiate, retained for custom/legacy/proposal scripts |
+| `needs an execution tier` | A genuinely unavailable action path |
+| `import not provided by the harness` | A non-standard host module absent from both the script registry and pinned `spectest` host |
 | `directive not in the reference grammar` | `assert_malformed_custom`, `assert_invalid_custom`, anything else unrecognised |
 
 Modules are assembled and decoded at command-execution time, never at
@@ -154,12 +161,21 @@ reads 0. The status stays in the harness for the next deferred feature.
 
 ## Where the numbers stand
 
-`WebAssembly/testsuite@de54fd27ecf3e68dfd16b6199c548df77b6a2cc1`, 288 scripts:
+`WebAssembly/testsuite@de54fd27ecf3e68dfd16b6199c548df77b6a2cc1`.
+The 257 pinned core scripts are fully judged:
 
 ```text
-ROOT      pass=64671 fail=33  skip=610  staged=0 total=65314
-PROPOSALS pass=533   fail=356 skip=922  staged=0 total=1811
-TOTAL files=288 errors=0 pass=65204 fail=389 skip=1532 staged=0 total=67125
+ROOT pass=65188 fail=0 skip=0 staged=0 total=65188
+TOTAL files=257 errors=0 pass=65188 fail=0 skip=0 staged=0 total=65188
+```
+
+The recursive 288-script mirror, including `custom/`, `legacy/`, and
+post-3.0 proposal trees, reports:
+
+```text
+ROOT pass=65208 fail=14 skip=90 staged=0 total=65312
+PROPOSALS pass=643 fail=354 skip=814 staged=0 total=1811
+TOTAL files=288 errors=0 pass=65851 fail=368 skip=904 staged=0 total=67123
 ```
 
 `ROOT` is everything outside `proposals/` (the 3.0 target plus the out-of-scope
@@ -169,21 +185,21 @@ runtime units — the interpreter's traps reach the runtime `MSG_*` strings the
 binary-only runs never did, and a raise site appends its context after the
 prefix rather than in front of it.
 
-Judged commands are `pass + fail` = **~65,593**. The `staged` column is **0**:
+Judged recursive commands are `pass + fail` = **66,219**. The `staged` column is **0**:
 Track H shipped exception-handling throwing, so `try_table`, `throw`, and
 `throw_ref` execute and `assert_exception` is judged — the whole core 3.0
-instruction set now runs. The `skip` column (~1,532) is the residue: assertions
-downstream of an unprovided import, host imports the harness does not provide,
-and `assert_unlinkable`.
+instruction set now runs. The pinned core `skip` column is 0. Recursive skips
+are proposal residue plus 20 testsuite-local custom directives and 70 legacy
+commands downstream of an intentionally unsupported legacy module.
 
-### What the 389 failures are
+### What the 368 recursive failures are
 
-The split is the headline: **356 are `PROPOSALS`** and only **33 are `ROOT`**, so
+The split is the headline: **354 are `PROPOSALS`** and only **14 are `ROOT`**, so
 the failures cluster in post-3.0 features, not in the 3.0 target — and none is a
 SIMD or exception-handling execution failure. None is a wrong-CLASS rejection
 between `malformed` and `invalid`.
 
-**`PROPOSALS` (356)** exercise features outside the pinned conformance target
+**`PROPOSALS` (354)** exercise features outside the pinned conformance target
 ([ADR-0004](../../docs/adr/0004-conformance-target-is-the-3-0-draft.md)):
 `custom-descriptors` (descriptor composite types, exact reference types, the
 `type … does not have a descriptor` family), `custom-page-sizes` (the `invalid
@@ -194,16 +210,16 @@ these must be accepted) and as **wording mismatches** on modules upstream also
 rejects. The justification holds — 3.0 does not have these features — but the
 honest label on the `expected=""` cases is *false rejection*, not diagnostics.
 
-**`ROOT` (33)** are three kinds:
+**`ROOT` (14)** are one deliberately excluded kind:
 
 - **Legacy exception handling** (`testsuite/legacy/try_catch.wast`,
-  `rethrow.wast`, `throw.wast`, `try_delegate.wast`, 16 cases) — the pre-3.0
+  `rethrow.wast`, `throw.wast`, `try_delegate.wast`, 14 cases) — the pre-3.0
   `try`/`catch`/`delegate`/`rethrow` encoding, out of 3.0 scope and staying
   failing (Track H covers the 3.0 `try_table` form only, which passes).
-- **Module-definition and instance harness forms** — commands the harness does
-  not yet model, rather than instruction or tier failures.
-- **A few assembler/decoder framing edges** — remaining text forms and message
-  boundaries that do not affect execution of accepted core 3.0 modules.
+
+Module definitions/instances, the standard `spectest` host,
+`assert_unlinkable`, inline module bodies, and the previously mismatched binary
+diagnostic boundaries are all judged in the clean pinned-core run.
 
 Extract the live signatures rather than trusting this list to stay exact — the
 grep in the "Reading the output" section keys on the `got=`/`expected=` pair and


### PR DESCRIPTION
## Summary

- make tier-divergence failures actionable in CI by retaining per-tier output and printing focused tally diffs
- enforce one conservative logical recursion limit across interpreter, JIT, and AOT so Intel macOS traps before the native stack overflows
- finish the pinned core spec-testsuite runner: standard `spectest` imports, `assert_unlinkable`, module definitions/instances, inline modules, and exact malformed-binary diagnostics
- update current-truth documentation to record a fully judged 257-script pinned core corpus

## Why

The prior CI failure exposed a real execution-tier divergence on x86_64 macOS: compiled recursive calls could reach FPC's native `EStackOverflow` before wasmlight emitted the required `call stack exhausted` trap. Once that was fixed, the remaining pinned-core failures and skips were harness and binary-diagnostic gaps rather than unsupported core execution behavior.

This change keeps validation and execution-tier boundaries intact while closing those gaps through the shipped decode, validate, instantiate, and execute paths.

## Spec evidence

Checked against `spec/main@d7b37e4170d8315f2f1283aed4e8076591a9a333`:

- `impl-exec` for implementation resource exhaustion
- `binary-int`, `binary-code`, `binary-section`, `binary-comptype`, `binary-name`, and `binary-list` for malformed-binary classification
- `exec-module` and `exec-instantiation` for link-time `assert_unlinkable` behavior
- the pinned reference `spectest.ml` for the standard host module

## Verification

- `git diff --check`
- `lwpt install --frozen`
- `lwpt format --check`
- `lwpt build` — 3/3 programs
- `lwpt test` — 44/44 suites, 1,224 tests
- `npx markdownlint-cli2 "**/*.md"` — 41 files, 0 issues
- pinned core, 257 scripts, interpreter/JIT/AOT: `pass=65188 fail=0 skip=0 staged=0`; JIT/AOT `compiled=8703`
- recursive mirror, all tiers identical: `pass=65851 fail=368 skip=904 staged=0`; remaining failures/skips are limited to post-3.0 proposals, testsuite-local custom directives, and the explicitly out-of-scope legacy exception encoding
- exact-head CI: six-platform `CI` matrix and four-job `PR` workflow passed at `7c805099bdfdcffd8410b02e54839eb604d9fd79`

## Boundaries

- no new dependencies or host capabilities
- no validation bypass or execution-tier-specific semantics
- no ADR required: the existing tier seam, validation ownership, error hierarchy, and pinned-conformance decisions are preserved
- no generated build state is committed
