### PR TITLE
perf(jit): specialize x64 scalar calls

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,75 @@
 # Handoff
 
+Updated: 2026-08-15 (x64 scalar-call specialization)
+
+## x64 scalar leaf calls and self-recursion
+
+- Fetched the remote default and created `codex/optimize-x64-jit` from exact
+  `origin/main@ed8d5d693bad9356feb914576d0dfe3f98ecec10`, after PR #6 had
+  landed the accepted Arm64 optimization waves. No rebase, force-push, remote
+  push, or PR creation was performed.
+- The two accepted commits are `cd21c4d` (`perf(jit): specialize x64 scalar
+  leaf calls`) and `9e68bb4` (`perf(jit): specialize x64 scalar self calls`).
+  The final source tree is `69aeb6eee23f7d10d69b8602d4e0f180845ecd27`.
+- The leaf wave adds a proof-gated x64 native scalar entry/core ABI. Eligible
+  one- or two-argument numeric leaves receive arguments in r8/r9 and return in
+  r8 through an aligned native-stack register file. The caller resolves the
+  live function/native entry, checks the exact shared depth and value limits,
+  and retains the generic compiled/interpreted/host fallback. The proof filter
+  prevents ineligible targets from paying the native-entry probe.
+- The self-recursion wave gives eligible one-argument numeric recursion a
+  local-core path. It computes the exact additional-frame budget as the
+  minimum of remaining depth and remaining value slots divided by the
+  function register count. Ordinary calls do not invent an epoch safepoint;
+  real IR backedges retain their existing checks. AOT ABI revision 14 rejects
+  artifacts produced for older x64 entry layouts.
+- Review initially found and prevented two leaf correctness defects: a mixed
+  scalar-call/tail-call function restored the wrong frame shape, and
+  select/rotate fallback emission could read unmaterialized parameter slots.
+  The final implementation threads the retained-frame shape through every
+  tail exit, materializes/coheres native parameters, and covers select and
+  both rotate widths in the x64 cache. Differential tests cover those paths,
+  local.set coherence, exact depth/value exhaustion and cleanup, sequential
+  self-calls, store reuse, JIT, and AOT. Final focused reviews found no
+  remaining ABI, PIC, cache-liveness, epoch, trap, or AOT issue.
+- Exact-main release baseline and evidence remain inside OrbStack `wasmx64`
+  at `/tmp/wasmlight-x64-ed8d5d6-baseline.Igxi43`. The VM-local baseline
+  binary hash is `3b816d...eea3`. All measurements used the explicit,
+  checksum-verified LWPT 0.6.0 binary under `/tmp/lwpt-0.6.0.Uq7icT/`, never
+  the stale LWPT 0.4.0 found on the VM PATH.
+- Serialized AOT command-level A/B used self-checking fresh processes,
+  compilation outside timing, one warm-up plus seven samples per binary and
+  order, and `/tmp/wasmlight-perf-gate.lock`. The accepted leaf path reduced
+  the 50-million-call workload from 7146.799 to 1905.832 ms forward and from
+  5540.303 to 1487.807 ms in reverse: 73.33% and 73.15% faster. A deliberately
+  ineligible scalar target was flat at +0.03% in its stable reversed schedule.
+- Against that accepted leaf baseline, native self-recursion reduced fib from
+  2984.799 to 533.784 ms forward and from 2982.862 to 534.782 ms in reverse:
+  82.12% and 82.07% faster. Its guard deltas were call -0.17%/+0.25%,
+  ineligible fallback -0.51%/+0.20%, loop -0.04%/-0.12%, memory
+  -0.13%/+0.04%, and startup order-flipped inside 10-24% short-process noise.
+  Raw accepted evidence is under `/tmp/wasmlight-x64-leaf-proof/measurement/`
+  and `/tmp/wasmlight-x64-self/measurement/` inside `wasmx64`.
+- One reviewed intermediate leaf candidate was rejected because every
+  syntactically qualifying call probed a nil native entry, producing a stable
+  2.25% regression across 50 million ineligible calls. The target-proof
+  filter removed that tax before acceptance. An earlier non-compact leaf
+  frame was also rejected after a repeatable roughly 1% memory regression.
+  Neither rejected form remains in the tree.
+- Final native macOS gates on exact head: frozen install, format, generated
+  agent reference, whitespace, Markdown lint, clean release/development
+  builds, and all 44 suites pass. The pinned 257-script core corpus at
+  `de54fd27` is byte-identical in interpreter/JIT/AOT at 65,188 pass and zero
+  fail/skip/staged/errors; JIT/AOT each compile 8,703 functions.
+- Final Linux/x86-64 proof used a fresh exact archive in OrbStack at
+  `/tmp/wasmlight-x64-final-9e68bb4.ujf8iw` (archive SHA-256
+  `cf431e7bfbf7223e5a7162917a0c67a99c2407a8f66f766c836c9be7cfc22961`).
+  FPC 3.2.2, frozen install, format, agents, clean release/development builds,
+  and all 44 suites pass. The same pinned core corpus is byte-identical at
+  65,188/0/0/0 in interpreter/JIT/AOT; x64 JIT/AOT each compile 8,704
+  functions. Timings are valid same-VM A/B evidence on virtualized amd64 over
+  an Arm host, not a native x64 hardware claim.
+
 Updated: 2026-08-15 (generic scalar direct-call specialization)
 
 ## Two-argument cross-function call path

--- a/source/units/Wasm.Aot.Test.pas
+++ b/source/units/Wasm.Aot.Test.pas
@@ -606,7 +606,7 @@ begin
     { The compiled functions are AOT-wired; the declined one is left nil, so it
       runs interpreted (aot-spec §4.2 step 6). }
     Expect<Boolean>(Store.Funcs[AddAddr].CompiledEntry <> nil).ToBe(True);
-    {$IFDEF WASM_JIT_ARM64}
+    {$IFDEF WASM_JIT_BACKEND}
     Expect<Boolean>(Store.Funcs[AddAddr].CompiledNativeScalarEntry =
       Store.Funcs[AddAddr].CompiledEntry).ToBe(True);
     {$ENDIF}

--- a/source/units/Wasm.Aot.pas
+++ b/source/units/Wasm.Aot.pas
@@ -181,7 +181,7 @@ begin
     Funcs[I].Compiled := False;
     if JitCanCompile(Fn) then
     begin
-      Code := JitStageFunctionBytes(AStore, Fn,
+      Code := JitStageFunctionBytes(AStore, Ir, Fn,
         Ir.FuncImportCount + UInt32(I), EntryOffset, RegCount);
       if Length(Code) > 0 then
       begin

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -337,7 +337,7 @@ const
     template's byte layout, a pinned-register reassignment, the entry-ABI shape.
     Bump it whenever position-independent codegen changes in a way that would
     make an existing artifact's bytes wrong. }
-  AOT_ABI_REVISION = 12;
+  AOT_ABI_REVISION = 13;
 
 { A deterministic 64-bit fingerprint over everything a serialized artifact's
   code bakes as a constant and the loading runtime must therefore agree on

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -337,7 +337,7 @@ const
     template's byte layout, a pinned-register reassignment, the entry-ABI shape.
     Bump it whenever position-independent codegen changes in a way that would
     make an existing artifact's bytes wrong. }
-  AOT_ABI_REVISION = 13;
+  AOT_ABI_REVISION = 14;
 
 { A deterministic 64-bit fingerprint over everything a serialized artifact's
   code bakes as a constant and the loading runtime must therefore agree on

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -2753,7 +2753,7 @@ begin
     DecodeModule(Bytes, Module);
     Ir := ValidateModule(Module, Bytes);
     Expect<Boolean>(JitCanNativeScalarSelf(@Ir.Functions[0],
-      Ir.FuncImportCount)).ToBe({$IFDEF WASM_JIT_ARM64}True{$ELSE}False{$ENDIF});
+      Ir.FuncImportCount)).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
   finally
     Ir.Free;
     Module.Free;
@@ -2805,7 +2805,7 @@ begin
     Ir := ValidateModule(Module, Bytes);
     Expect<Boolean>(JitCanNativeScalarSelf(@Ir.Functions[0],
       Ir.FuncImportCount)).ToBe(
-      {$IFDEF WASM_JIT_ARM64}True{$ELSE}False{$ENDIF});
+      {$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
   finally
     Ir.Free;
     Module.Free;

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -364,6 +364,47 @@ begin
   ]);
 end;
 
+{ Native leaf coverage for the two operations whose x64 forms otherwise use
+  memory-backed templates: rotate-left and select. Each caller forces a real
+  compiled-to-compiled scalar entry rather than invoking the helper directly. }
+function LeafSelectRotateModuleBytes: TWasmBytes;
+begin
+  Result := Cat([
+    BLit(WASM_HEADER),
+    Sect(1, VecOf([BLit([$60, $02, $7F, $7F, $01, $7F])])),
+    Sect(3, VecOf([BLit([$00]), BLit([$00]), BLit([$00]), BLit([$00])])),
+    Sect(7, VecOf([
+      ExportEntry('rotl_helper', $00, 0),
+      ExportEntry('rotl', $00, 1),
+      ExportEntry('select_helper', $00, 2),
+      ExportEntry('select', $00, 3)])),
+    Sect(10, VecOf([
+      CodeEntry([$00, $20, $00, $20, $01, $77, $0B]),
+      CodeEntry([$00, $20, $00, $20, $01, $10, $00, $0B]),
+      CodeEntry([$00, $20, $00, $20, $01, $20, $00, $1B, $0B]),
+      CodeEntry([$00, $20, $00, $20, $01, $10, $02, $0B])]))
+  ]);
+end;
+
+{ A scalar call selects the retained-context x64 frame, then return_call exits
+  through the tail channel. Both exits must restore the same frame shape. }
+function MixedScalarTailModuleBytes: TWasmBytes;
+begin
+  Result := Cat([
+    BLit(WASM_HEADER),
+    Sect(1, VecOf([BLit([$60, $01, $7F, $01, $7F])])),
+    Sect(3, VecOf([BLit([$00]), BLit([$00]), BLit([$00])])),
+    Sect(7, VecOf([
+      ExportEntry('helper', $00, 0),
+      ExportEntry('target', $00, 1),
+      ExportEntry('run', $00, 2)])),
+    Sect(10, VecOf([
+      CodeEntry([$00, $20, $00, $41, $01, $6A, $0B]),
+      CodeEntry([$00, $20, $00, $0B]),
+      CodeEntry([$00, $20, $00, $10, $00, $12, $01, $0B])]))
+  ]);
+end;
+
 { call_indirect over a 4-entry table holding [$double, $other, null, null]:
 
     (func $double (param i32) (result i32) (i32.mul (local.get 0) 2))  ; type 0
@@ -1750,10 +1791,8 @@ begin
   Expect<Boolean>(FStore.Funcs[AddAddr].CompiledEntry <> nil).ToBe(True);
   Expect<Boolean>(FStore.Funcs[AddAddr].CompiledDirectEntry =
     FStore.Funcs[AddAddr].CompiledEntry).ToBe(True);
-  {$IFDEF WASM_JIT_ARM64}
   Expect<Boolean>(FStore.Funcs[AddAddr].CompiledNativeScalarEntry =
     FStore.Funcs[AddAddr].CompiledEntry).ToBe(True);
-  {$ENDIF}
   Expect<Boolean>(FJit.ForceCompile(AddAddr)).ToBe(True);
   {$ELSE}
   Expect<Boolean>(Compiled).ToBe(False);
@@ -2793,7 +2832,7 @@ begin
     DecodeModule(Bytes, Module);
     Ir := ValidateModule(Module, Bytes);
     Expect<Boolean>(JitCanNativeScalarLeaf(@Ir.Functions[0])).ToBe(
-      {$IFDEF WASM_JIT_ARM64}True{$ELSE}False{$ENDIF});
+      {$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
     Expect<Boolean>(JitCanNativeScalarLeaf(@Ir.Functions[1])).ToBe(False);
     RunRegisterCount := Ir.Functions[1].RegisterCount;
   finally
@@ -2816,6 +2855,16 @@ begin
   CompileExports(['helper', 'run']);
   Expect<Boolean>(DiffModule(LeafLocalSetModuleBytes, 'run',
     [MakeValueI32(1)])).ToBe(JIT_BACKEND_AVAILABLE);
+
+  CompileExports(['rotl_helper', 'rotl', 'select_helper', 'select']);
+  Expect<Boolean>(DiffModule(LeafSelectRotateModuleBytes, 'rotl',
+    [MakeValueI32(1), MakeValueI32(5)])).ToBe(JIT_BACKEND_AVAILABLE);
+  Expect<Boolean>(DiffModule(LeafSelectRotateModuleBytes, 'select',
+    [MakeValueI32(7), MakeValueI32(9)])).ToBe(JIT_BACKEND_AVAILABLE);
+
+  CompileExports(['helper', 'target', 'run']);
+  Expect<Boolean>(DiffModule(MixedScalarTailModuleBytes, 'run',
+    [MakeValueI32(41)])).ToBe(JIT_BACKEND_AVAILABLE);
 
   { The lightweight call must enforce the same logical depth boundary as the
     interpreter before touching native stack state. DiffModule also asserts

--- a/source/units/Wasm.Jit.X64.Test.pas
+++ b/source/units/Wasm.Jit.X64.Test.pas
@@ -57,6 +57,7 @@ type
     procedure TestEpilogueBytes;
     procedure TestEpochCaptureBytes;
     procedure TestEpochCheckCoreBytes;
+    procedure TestNativeSelfCallBytes;
     procedure TestRuntimeCallMarshalBytes;
     procedure TestPositionIndependentSequences;
     procedure TestSlotOffset;
@@ -513,6 +514,29 @@ begin
   end;
 end;
 
+procedure TX64Tests.TestNativeSelfCallBytes;
+var
+  Buf: TWasmCodeBuffer;
+begin
+  { test r12; je exhausted; r12--; push rbx; 16-byte regfile; rbx:=rsp;
+    store r8 parameter; call core; restore; r12++. Both branches are rel32
+    placeholders resolved after the complete function is emitted. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    Buf.NewLabel;
+    Buf.NewLabel;
+    X64EmitNativeSelfCall(Buf, 2, 0, 0, 1);
+    CheckSeq(Buf, [$4D, $85, $E4, $0F, $84, $00, $00, $00, $00,
+      $B8, $01, $00, $00, $00, $49, $29, $C4, $53,
+      $48, $83, $EC, $10, $48, $89, $E3, $4C, $89, $03,
+      $E8, $00, $00, $00, $00, $48, $83, $C4, $10, $5B,
+      $B8, $01, $00, $00, $00, $49, $01, $C4]);
+    Expect<Integer>(Buf.PatchCount).ToBe(2);
+  finally
+    Buf.Free;
+  end;
+end;
+
 procedure TX64Tests.TestRuntimeCallMarshalBytes;
 var
   Buf: TWasmCodeBuffer;
@@ -689,6 +713,8 @@ begin
   Test('the epoch capture emits the asserted bytes', TestEpochCaptureBytes);
   Test('the epoch-check load+compare core emits the asserted bytes',
     TestEpochCheckCoreBytes);
+  Test('the native self-call frame emits the asserted bytes',
+    TestNativeSelfCallBytes);
   Test('the runtime/vec helper-call marshaling emits the asserted bytes',
     TestRuntimeCallMarshalBytes);
   Test('helper calls and the IR pointer are position-independent',

--- a/source/units/Wasm.Jit.X64.Test.pas
+++ b/source/units/Wasm.Jit.X64.Test.pas
@@ -365,6 +365,17 @@ procedure TX64Tests.TestBranchPlaceholders;
 var
   Buf: TWasmCodeBuffer;
 begin
+  { call rel32 placeholder = E8 00 00 00 00. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    Buf.NewLabel;
+    X64EmitCallTo(Buf, 0);
+    CheckSeq(Buf, [$E8, $00, $00, $00, $00]);
+    Expect<Integer>(Buf.PatchCount).ToBe(1);
+  finally
+    Buf.Free;
+  end;
+
   { jmp rel32 placeholder = E9 00 00 00 00. }
   Buf := TWasmCodeBuffer.Create;
   try
@@ -418,16 +429,29 @@ procedure TX64Tests.TestPrologueBytes;
 var
   Buf: TWasmCodeBuffer;
 begin
-  { Position-independent prologue: SIX callee-saved pins pushed (rbx, r12-r15,
-    rbp) + alignment pad + arg moves (aot-spec §1.2/§1.3/§4.3).
-    push rbx = 53 ; push r12 = 41 54 ; push r13 = 41 55 ; push r14 = 41 56 ;
-    push r15 = 41 57 ; push rbp = 55 ; sub rsp,8 = 48 83 EC 08 ;
-    mov rbx,rdi = 48 89 FB ; mov r12,rsi = 49 89 F4 ; mov rbp,rdx = 48 89 D5. }
+  { The ordinary frame retains its original single alignment/memory slot. }
   Buf := TWasmCodeBuffer.Create;
   try
     X64EmitPrologue(Buf);
     CheckSeq(Buf, [$53, $41, $54, $41, $55, $41, $56, $41, $57, $55,
       $48, $83, $EC, $08, $48, $89, $FB, $49, $89, $F4, $48, $89, $D5]);
+  finally
+    Buf.Free;
+  end;
+
+  { Position-independent scalar-call prologue: SIX callee-saved pins pushed
+    (rbx, r12-r15, rbp) + context/memory/alignment slots + arg moves and
+    context retention.
+    push rbx = 53 ; push r12 = 41 54 ; push r13 = 41 55 ; push r14 = 41 56 ;
+    push r15 = 41 57 ; push rbp = 55 ; sub rsp,24 = 48 83 EC 18 ;
+    mov rbx,rdi = 48 89 FB ; mov r12,rsi = 49 89 F4 ; mov rbp,rdx = 48 89 D5 ;
+    mov [rsp+8],rcx = 48 89 4C 24 08. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64EmitPrologue(Buf, True);
+    CheckSeq(Buf, [$53, $41, $54, $41, $55, $41, $56, $41, $57, $55,
+      $48, $83, $EC, $18, $48, $89, $FB, $49, $89, $F4, $48, $89, $D5,
+      $48, $89, $4C, $24, $08]);
   finally
     Buf.Free;
   end;
@@ -437,12 +461,21 @@ procedure TX64Tests.TestEpilogueBytes;
 var
   Buf: TWasmCodeBuffer;
 begin
-  { add rsp,8; pop rbp; pop r15; pop r14; pop r13; pop r12; pop rbx; ret.
-    48 83 C4 08 | 5D | 41 5F | 41 5E | 41 5D | 41 5C | 5B | C3. }
+  { The ordinary frame restores its single alignment/memory slot. }
   Buf := TWasmCodeBuffer.Create;
   try
     X64EmitEpilogue(Buf);
     CheckSeq(Buf, [$48, $83, $C4, $08, $5D, $41, $5F, $41, $5E, $41, $5D,
+      $41, $5C, $5B, $C3]);
+  finally
+    Buf.Free;
+  end;
+
+  { add rsp,24; pop rbp; pop r15; pop r14; pop r13; pop r12; pop rbx; ret. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64EmitEpilogue(Buf, True);
+    CheckSeq(Buf, [$48, $83, $C4, $18, $5D, $41, $5F, $41, $5E, $41, $5D,
       $41, $5C, $5B, $C3]);
   finally
     Buf.Free;
@@ -512,8 +545,7 @@ begin
     Buf.Free;
   end;
 
-  { PinMemory: resolve memory 7 through the helper table, then retain the
-    stable instance pointer in the existing [rsp] alignment slot. }
+  { PinMemory: retain the stable instance pointer in the first frame slot. }
   Buf := TWasmCodeBuffer.Create;
   try
     X64EmitPinMemory(Buf, 7);

--- a/source/units/Wasm.Jit.X64.pas
+++ b/source/units/Wasm.Jit.X64.pas
@@ -315,6 +315,11 @@ procedure X64EmitNativeLeafEntry(const ABuf: TWasmCodeBuffer;
 procedure X64EmitNativeCoreWrapperCall(const ABuf: TWasmCodeBuffer;
   const AParamCount, AParam0Reg, AParam1Reg, AResultReg: UInt32;
   const ACoreLabel: TWasmJitLabel);
+procedure X64EmitNativeSelfBudget(const ABuf: TWasmCodeBuffer;
+  const ARegisterCount: UInt32);
+procedure X64EmitNativeSelfCall(const ABuf: TWasmCodeBuffer;
+  const ARegisterCount, AParamReg: UInt32;
+  const ACoreLabel, AExhaustedLabel: TWasmJitLabel);
 { Pin the per-process helper-table base in r15 (aot-spec §1.2/§4.3): loads it
   from the store field (r12 + AHelperTableOffset) ONCE. Emitted by the driver
   right after the prologue; the exec-only encoder tests skip it. }
@@ -362,7 +367,8 @@ function X64EmitOp(const ABuf: TWasmCodeBuffer;
   const AUseNativeScalarCall: Boolean = False): Boolean;
 procedure X64InitRegCache(out ACache: TX64RegCache);
 procedure X64SeedNativeCoreCache(var ACache: TX64RegCache;
-  const AParamCount, AParam0Slot, AParam1Slot: UInt32);
+  const AParamCount, AParam0Slot, AParam1Slot: UInt32;
+  const AStaticParams: Boolean = True);
 procedure X64EnableStaticRegCache(const ABuf: TWasmCodeBuffer;
   var ACache: TX64RegCache; const ASlots: array of UInt32);
 procedure X64FlushRegCache(const ABuf: TWasmCodeBuffer;
@@ -375,7 +381,9 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
 function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
   const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory,
-  ANativeScalarLeaf: Boolean; const ANativeResultReg: UInt32;
+  ANativeScalarCore, ANativeScalarSelf: Boolean;
+  const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
+  const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
   const ARetainContext, AUseNativeScalarCall: Boolean;
   var ACache: TX64RegCache): Boolean; overload;
 procedure X64EmitCompareBranchCached(const ABuf: TWasmCodeBuffer;
@@ -511,13 +519,16 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   var ACache: TX64RegCache): Boolean;
 begin
   Result := X64EmitOpCached(ABuf, AIns, AAux, AInsIndex, AAddr64,
-    AUsePinnedMemory, False, 0, False, False, ACache);
+    AUsePinnedMemory, False, False, 0, 0, 0, -1, -1, False, False,
+    ACache);
 end;
 
 function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
   const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory,
-  ANativeScalarLeaf: Boolean; const ANativeResultReg: UInt32;
+  ANativeScalarCore, ANativeScalarSelf: Boolean;
+  const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
+  const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
   const ARetainContext, AUseNativeScalarCall: Boolean;
   var ACache: TX64RegCache): Boolean;
 begin
@@ -563,9 +574,26 @@ begin
         Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex, ARetainContext,
           AUseNativeScalarCall);
       end;
+    iroCall:
+      if ANativeScalarSelf then
+      begin
+        X64CachedLoad(ABuf, ACache, X64_R8,
+          IrAuxBlockItem(AAux, AIns.A, 0));
+        X64InvalidateRegCache(ACache);
+        X64EmitNativeSelfCall(ABuf, ANativeRegisterCount, ANativeParamReg,
+          ANativeCoreLabel, ANativeExhaustedLabel);
+        X64CachedStore(ABuf, ACache, X64_R8,
+          IrAuxBlockItem(AAux, AIns.B, 0));
+      end
+      else
+      begin
+        X64InvalidateRegCache(ACache);
+        Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex, ARetainContext,
+          AUseNativeScalarCall);
+      end;
     iroReturn:
       begin
-        if ANativeScalarLeaf then
+        if ANativeScalarCore then
         begin
           X64CachedLoad(ABuf, ACache, X64_R8, ANativeResultReg);
           X64EmitRet(ABuf);
@@ -657,13 +685,16 @@ begin
 end;
 
 procedure X64SeedNativeCoreCache(var ACache: TX64RegCache;
-  const AParamCount, AParam0Slot, AParam1Slot: UInt32);
+  const AParamCount, AParam0Slot, AParam1Slot: UInt32;
+  const AStaticParams: Boolean);
 begin
   X64InitRegCache(ACache);
-  ACache.StaticAllocation := True;
-  ACache.FixedWriteThrough := True;
+  ACache.StaticAllocation := AStaticParams;
+  ACache.FixedWriteThrough := AStaticParams;
   ACache.Entries[0].Valid := True;
   ACache.Entries[0].Slot := AParam0Slot;
+  if not AStaticParams then
+    ACache.Next := 1;
   if AParamCount = 2 then
   begin
     ACache.Entries[1].Valid := True;
@@ -2965,6 +2996,57 @@ begin
     X64EmitLoadSlot64(ABuf, X64_R9, AParam1Reg);
   X64EmitCallTo(ABuf, ACoreLabel);
   X64EmitStoreSlot64(ABuf, X64_R8, AResultReg);
+end;
+
+procedure X64EmitNativeSelfBudget(const ABuf: TWasmCodeBuffer;
+  const ARegisterCount: UInt32);
+var
+  FO: TWasmJitFrameOffsets;
+begin
+  FO := WasmJitFrameOffsets;
+  { The external wrapper owns the one published activation. Pin the exact
+    additional lightweight-frame budget in r12, whose saved store value is no
+    longer needed by this closed helper-free numeric core. }
+  X64EmitLoadMem64(ABuf, X64_RCX, X64_RSP, 8);       { context }
+  X64EmitLoadMem64(ABuf, X64_RAX, X64_RCX, Int32(FO.CtxDepthCap));
+  X64EmitLoadMem64(ABuf, X64_RDX, X64_RCX, Int32(FO.CtxDepth));
+  X64EmitAluRegReg(ABuf, $29, True, X64_RAX, X64_RDX);
+  X64EmitMovRegReg(ABuf, X64_R12, X64_RAX);
+
+  X64EmitLoadMem64(ABuf, X64_RAX, X64_RCX, Int32(FO.CtxValueCap));
+  X64EmitLoadMem64(ABuf, X64_RDX, X64_RCX, Int32(FO.CtxValueTop));
+  X64EmitAluRegReg(ABuf, $29, True, X64_RAX, X64_RDX);
+  X64EmitMovRegImm32(ABuf, X64_RCX, ARegisterCount);
+  X64EmitAluRegReg(ABuf, $31, True, X64_RDX, X64_RDX);
+  X64EmitDivReg(ABuf, False, True, X64_RCX);
+  X64EmitAluRegReg(ABuf, $39, True, X64_RAX, X64_R12);
+  X64EmitCmovcc(ABuf, X64_CC_B, True, X64_R12, X64_RAX);
+end;
+
+procedure X64EmitNativeSelfCall(const ABuf: TWasmCodeBuffer;
+  const ARegisterCount, AParamReg: UInt32;
+  const ACoreLabel, AExhaustedLabel: TWasmJitLabel);
+var
+  FrameBytes: UInt32;
+begin
+  { Test and decrement before native-stack mutation. Ordinary calls are not
+    epoch safepoints; real IR back-edges retain their existing checks. }
+  X64EmitAluRegReg(ABuf, $85, True, X64_R12, X64_R12);
+  X64EmitJccTo(ABuf, X64_CC_E, UInt32(AExhaustedLabel));
+  X64EmitMovRegImm32(ABuf, X64_RAX, 1);
+  X64EmitAluRegReg(ABuf, $29, True, X64_R12, X64_RAX);
+
+  FrameBytes := (ARegisterCount * X64_SLOT_SIZE + 15) and not UInt32(15);
+  X64EmitPushReg(ABuf, X64_RBX);
+  X64EmitSubRsp(ABuf, Int32(FrameBytes));
+  X64EmitMovRegReg(ABuf, X64_REG_REGFILE, X64_RSP);
+  X64EmitStoreSlot64(ABuf, X64_R8, AParamReg);
+  X64EmitCallTo(ABuf, ACoreLabel);
+  X64EmitAddRsp(ABuf, Int32(FrameBytes));
+  X64EmitPopReg(ABuf, X64_RBX);
+
+  X64EmitMovRegImm32(ABuf, X64_RAX, 1);
+  X64EmitAluRegReg(ABuf, $01, True, X64_R12, X64_RAX);
 end;
 
 procedure X64EmitPinHelperTable(const ABuf: TWasmCodeBuffer;

--- a/source/units/Wasm.Jit.X64.pas
+++ b/source/units/Wasm.Jit.X64.pas
@@ -24,9 +24,11 @@
     r13 = &Store.Epoch        (r12 + StoreEpoch offset)
     r14 = the epoch captured at entry (Store.EpochSnapshot, §6)
   Scratch is rax/rcx/rdx (caller-saved, dead at op boundaries); the SysV arg
-  registers marshal helper arguments. The prologue pushes rbx/r12/r13/r14 and a
-  single 8-byte pad (keeping rsp 16-aligned for calls); the epilogue reverses
-  it. A trap unwinds through LongJmp to the per-invocation trampoline
+  registers marshal helper arguments. The prologue pushes rbx/r12/r13/r14 and
+  reserves one 8-byte alignment/memory slot; scalar-call-bearing functions use
+  three slots so the live interpreter context can be retained. The epilogue
+  reverses the selected shape. A trap unwinds through LongJmp
+  to the per-invocation trampoline
   (ADR-0009), which restores the caller's callee-saved set from its setjmp, so a
   skipped epilogue on the trap path is correct.
 
@@ -110,6 +112,7 @@ type
     Entries: array[0..3] of TX64RegCacheEntry;
     Next: Byte;
     StaticAllocation: Boolean;
+    FixedWriteThrough: Boolean;
   end;
 
 const
@@ -292,6 +295,9 @@ procedure X64EmitAddRsp(const ABuf: TWasmCodeBuffer; const AImm: Int32);
 procedure X64EmitSubRsp(const ABuf: TWasmCodeBuffer; const AImm: Int32);
 { call reg (FF /2). }
 procedure X64EmitCallReg(const ABuf: TWasmCodeBuffer; const AReg: Byte);
+{ call rel32 to a code-buffer label. }
+procedure X64EmitCallTo(const ABuf: TWasmCodeBuffer;
+  const ATarget: TWasmJitLabel);
 
 { jmp rel32 / jcc rel32 placeholders (rel32 = 0), recording a patch against the
   target label (= the target IR-instruction index; the driver binds one label
@@ -301,20 +307,28 @@ procedure X64EmitJccTo(const ABuf: TWasmCodeBuffer; const ACc: Byte;
   const ATarget: UInt32);
 
 { --- the Wave-2 frame (jit-spec §5.2/§5.3/§6) --------------------------- }
-procedure X64EmitPrologue(const ABuf: TWasmCodeBuffer);
+procedure X64EmitPrologue(const ABuf: TWasmCodeBuffer;
+  const ARetainContext: Boolean = False);
+procedure X64EmitNativeLeafEntry(const ABuf: TWasmCodeBuffer;
+  const ARegisterCount, AParamCount, AParam0Reg, AParam1Reg: UInt32;
+  const ACoreLabel, AExternalLabel: TWasmJitLabel);
+procedure X64EmitNativeCoreWrapperCall(const ABuf: TWasmCodeBuffer;
+  const AParamCount, AParam0Reg, AParam1Reg, AResultReg: UInt32;
+  const ACoreLabel: TWasmJitLabel);
 { Pin the per-process helper-table base in r15 (aot-spec §1.2/§4.3): loads it
   from the store field (r12 + AHelperTableOffset) ONCE. Emitted by the driver
   right after the prologue; the exec-only encoder tests skip it. }
 procedure X64EmitPinHelperTable(const ABuf: TWasmCodeBuffer;
   const AHelperTableOffset: NativeUInt);
 { Resolve a single function memory once and keep its stable instance pointer in
-  the prologue's otherwise-unused alignment slot at [rsp]. Scalar accesses
+  the prologue's memory slot at [rsp]. Scalar accesses
   still reload live Base/ByteSize fields, so memory.grow semantics are unchanged. }
 procedure X64EmitPinMemory(const ABuf: TWasmCodeBuffer;
   const AMemoryIndex: UInt32);
 procedure X64EmitEpochCapture(const ABuf: TWasmCodeBuffer;
   const AEpochOffset, ASnapshotOffset: NativeUInt);
-procedure X64EmitEpilogue(const ABuf: TWasmCodeBuffer);
+procedure X64EmitEpilogue(const ABuf: TWasmCodeBuffer;
+  const ARetainContext: Boolean = False);
 
 { Emit an indirect call to helper slot AHelper through the pinned helper table:
   `call qword [r15 + Ord(AHelper)*8]` (aot-spec §1.2) — position-independent. }
@@ -343,8 +357,12 @@ function X64CanEmitOp(const AOp: TWasmIrOp): Boolean;
   AInsIndex*SizeOf(TWasmIrInstr), so nothing is baked. }
 function X64EmitOp(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
-  const AInsIndex: UInt32): Boolean;
+  const AInsIndex: UInt32;
+  const ARetainContext: Boolean = False;
+  const AUseNativeScalarCall: Boolean = False): Boolean;
 procedure X64InitRegCache(out ACache: TX64RegCache);
+procedure X64SeedNativeCoreCache(var ACache: TX64RegCache;
+  const AParamCount, AParam0Slot, AParam1Slot: UInt32);
 procedure X64EnableStaticRegCache(const ABuf: TWasmCodeBuffer;
   var ACache: TX64RegCache; const ASlots: array of UInt32);
 procedure X64FlushRegCache(const ABuf: TWasmCodeBuffer;
@@ -353,7 +371,13 @@ procedure X64InvalidateRegCache(var ACache: TX64RegCache);
 function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
   const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory: Boolean;
-  var ACache: TX64RegCache): Boolean;
+  var ACache: TX64RegCache): Boolean; overload;
+function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
+  const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory,
+  ANativeScalarLeaf: Boolean; const ANativeResultReg: UInt32;
+  const ARetainContext, AUseNativeScalarCall: Boolean;
+  var ACache: TX64RegCache): Boolean; overload;
 procedure X64EmitCompareBranchCached(const ABuf: TWasmCodeBuffer;
   const ACompare, ABranch: TWasmIrInstr; var ACache: TX64RegCache);
 function X64CanEmitInstr(const AIns: TWasmIrInstr;
@@ -395,6 +419,8 @@ procedure X64CachedAlu(const ABuf: TWasmCodeBuffer;
 procedure X64CachedShift(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const ASubop: Byte; const AWide: Boolean;
   var ACache: TX64RegCache); forward;
+procedure X64CachedSelect(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; var ACache: TX64RegCache); forward;
 procedure X64CachedRel(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const ACc: Byte; const AWide: Boolean;
   var ACache: TX64RegCache); forward;
@@ -484,6 +510,17 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory: Boolean;
   var ACache: TX64RegCache): Boolean;
 begin
+  Result := X64EmitOpCached(ABuf, AIns, AAux, AInsIndex, AAddr64,
+    AUsePinnedMemory, False, 0, False, False, ACache);
+end;
+
+function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
+  const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory,
+  ANativeScalarLeaf: Boolean; const ANativeResultReg: UInt32;
+  const ARetainContext, AUseNativeScalarCall: Boolean;
+  var ACache: TX64RegCache): Boolean;
+begin
   Result := True;
   if X64ScalarMemoryOp(AIns.Op) then
   begin
@@ -523,12 +560,27 @@ begin
           The epoch-only back-edge cannot collect on its fallthrough and the
           mismatch path traps without returning, so numeric slots need no
           canonical writeback here. Observable exits still flush below. }
-        Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex);
+        Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex, ARetainContext,
+          AUseNativeScalarCall);
       end;
-    iroReturn, iroUnreachable:
+    iroReturn:
+      begin
+        if ANativeScalarLeaf then
+        begin
+          X64CachedLoad(ABuf, ACache, X64_R8, ANativeResultReg);
+          X64EmitRet(ABuf);
+        end
+        else
+        begin
+          X64FlushRegCache(ABuf, ACache);
+          X64EmitEpilogue(ABuf, ARetainContext);
+        end;
+      end;
+    iroUnreachable:
       begin
         X64FlushRegCache(ABuf, ACache);
-        Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex);
+        Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex, ARetainContext,
+          AUseNativeScalarCall);
       end;
     iroI32Eqz, iroI64Eqz:
       begin
@@ -567,6 +619,7 @@ begin
     iroI32Shl: X64CachedShift(ABuf, AIns, 4, False, ACache);
     iroI32ShrS: X64CachedShift(ABuf, AIns, 7, False, ACache);
     iroI32ShrU: X64CachedShift(ABuf, AIns, 5, False, ACache);
+    iroI32Rotl: X64CachedShift(ABuf, AIns, 0, False, ACache);
     iroI32Rotr: X64CachedShift(ABuf, AIns, 1, False, ACache);
     iroI64Add: X64CachedAlu(ABuf, AIns, $01, True, False, ACache);
     iroI64Sub: X64CachedAlu(ABuf, AIns, $29, True, False, ACache);
@@ -577,10 +630,13 @@ begin
     iroI64Shl: X64CachedShift(ABuf, AIns, 4, True, ACache);
     iroI64ShrS: X64CachedShift(ABuf, AIns, 7, True, ACache);
     iroI64ShrU: X64CachedShift(ABuf, AIns, 5, True, ACache);
+    iroI64Rotl: X64CachedShift(ABuf, AIns, 0, True, ACache);
     iroI64Rotr: X64CachedShift(ABuf, AIns, 1, True, ACache);
+    iroSelect: X64CachedSelect(ABuf, AIns, ACache);
   else
     X64InvalidateRegCache(ACache);
-    Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex);
+    Result := X64EmitOp(ABuf, AIns, AAux, AInsIndex, ARetainContext,
+      AUseNativeScalarCall);
   end;
 end;
 
@@ -598,6 +654,21 @@ end;
 procedure X64InitRegCache(out ACache: TX64RegCache);
 begin
   FillChar(ACache, SizeOf(ACache), 0);
+end;
+
+procedure X64SeedNativeCoreCache(var ACache: TX64RegCache;
+  const AParamCount, AParam0Slot, AParam1Slot: UInt32);
+begin
+  X64InitRegCache(ACache);
+  ACache.StaticAllocation := True;
+  ACache.FixedWriteThrough := True;
+  ACache.Entries[0].Valid := True;
+  ACache.Entries[0].Slot := AParam0Slot;
+  if AParamCount = 2 then
+  begin
+    ACache.Entries[1].Valid := True;
+    ACache.Entries[1].Slot := AParam1Slot;
+  end;
 end;
 
 procedure X64EnableStaticRegCache(const ABuf: TWasmCodeBuffer;
@@ -691,6 +762,8 @@ begin
       Host := X64CacheHostReg(Victim);
       if ASrc <> Host then
         X64EmitMovRegReg(ABuf, Host, ASrc);
+      if ACache.FixedWriteThrough then
+        X64EmitStoreSlot64(ABuf, Host, ASlot);
       Exit;
     end;
     X64EmitStoreSlot64(ABuf, ASrc, ASlot);
@@ -739,6 +812,17 @@ begin
   X64CachedLoad(ABuf, ACache, X64_RAX, AIns.A);
   X64CachedLoad(ABuf, ACache, X64_RCX, AIns.B);
   X64EmitShiftCl(ABuf, ASubop, AWide, X64_RAX);
+  X64CachedStore(ABuf, ACache, X64_RAX, AIns.Dest);
+end;
+
+procedure X64CachedSelect(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; var ACache: TX64RegCache);
+begin
+  X64CachedLoad(ABuf, ACache, X64_RAX, AIns.A);
+  X64CachedLoad(ABuf, ACache, X64_RCX, AIns.B);
+  X64CachedLoad(ABuf, ACache, X64_RDX, UInt32(AIns.Imm));
+  X64EmitAluRegReg(ABuf, $85, False, X64_RDX, X64_RDX);
+  X64EmitCmovcc(ABuf, X64_CC_E, True, X64_RAX, X64_RCX);
   X64CachedStore(ABuf, ACache, X64_RAX, AIns.Dest);
 end;
 
@@ -882,10 +966,13 @@ end;
 
 type
   { The compiled entry's ABI (aot-spec §1.3/§4.3): regbase in rdi, store in rsi,
-    IR-code base @Fn^.Code[0] in rdx; cdecl = SysV. The prologue pins them in
-    rbx / r12 / rbp, and pins the helper-table base (r15) off the store. }
+    IR-code base @Fn^.Code[0] in rdx, interpreter context in rcx; cdecl = SysV.
+    The prologue pins the first three in rbx / r12 / rbp and pins the helper-
+    table base (r15) off the store. Scalar-call-bearing bodies retain rcx in
+    their extended frame. }
   TX64CompiledEntry = procedure(const ARegBase: PWasmValue;
-    const AStore: TWasmStore; const AIrBase: PWasmIrInstr); cdecl;
+    const AStore: TWasmStore; const AIrBase: PWasmIrInstr;
+    const ACtx: PWasmInterpContext); cdecl;
 
 { Fix A: the pending tail channel is the SHARED Wasm.Interp.GTierTail
   (TierTailSlot), written by both a compiled body's return_call* helper and the
@@ -1120,7 +1207,7 @@ begin
       UnwindException(Ctx, TWasmRef(Seam.ExnRef), False);
       Exit;
     end;
-    Entry(Base, AStore, IrBase);
+    Entry(Base, AStore, IrBase, Ctx);
     CurrentSeamCatch := Seam.Prev;
 
     JitLeaveFrame(Ctx);
@@ -2763,6 +2850,17 @@ begin
   ABuf.EmitByte($D0 or (AReg and 7));
 end;
 
+procedure X64EmitCallTo(const ABuf: TWasmCodeBuffer;
+  const ATarget: TWasmJitLabel);
+var
+  Site: Integer;
+begin
+  Site := ABuf.CurrentOffset;
+  ABuf.EmitByte($E8);
+  ABuf.EmitU32(0);
+  ABuf.AddPatch(Site, ATarget, X64_PATCH_JMP32);
+end;
+
 procedure X64EmitCallHelper(const ABuf: TWasmCodeBuffer;
   const AHelper: TWasmAotHelper);
 begin
@@ -2810,7 +2908,8 @@ end;
 {  the Wave-2 frame + branch patching                                    }
 { ===================================================================== }
 
-procedure X64EmitPrologue(const ABuf: TWasmCodeBuffer);
+procedure X64EmitPrologue(const ABuf: TWasmCodeBuffer;
+  const ARetainContext: Boolean);
 begin
   X64EmitPushReg(ABuf, X64_RBX);
   X64EmitPushReg(ABuf, X64_R12);
@@ -2818,12 +2917,54 @@ begin
   X64EmitPushReg(ABuf, X64_R14);
   X64EmitPushReg(ABuf, X64_R15);
   X64EmitPushReg(ABuf, X64_RBP);
-  { Six 8-byte pushes leave rsp 8 mod 16 (entry is 8 mod 16); the pad restores
-    16-alignment so every CALL below sees an aligned stack (SysV §3.2.2). }
-  X64EmitSubRsp(ABuf, 8);
+  { Six pushes leave rsp 8 mod 16. One slot restores call alignment and may
+    retain a pinned memory. Scalar-call-bearing functions reserve two further
+    slots so the second can retain their live interpreter context. }
+  if ARetainContext then
+    X64EmitSubRsp(ABuf, 24)
+  else
+    X64EmitSubRsp(ABuf, 8);
   X64EmitMovRegReg(ABuf, X64_REG_REGFILE, X64_RDI);   { rbx := regbase (arg0) }
   X64EmitMovRegReg(ABuf, X64_REG_STORE, X64_RSI);     { r12 := store (arg1) }
   X64EmitMovRegReg(ABuf, X64_REG_IRBASE, X64_RDX);    { rbp := IR base (arg2) }
+  if ARetainContext then
+    X64EmitStoreMem64(ABuf, X64_RCX, X64_RSP, 8);     { context (arg3) }
+end;
+
+procedure X64EmitNativeLeafEntry(const ABuf: TWasmCodeBuffer;
+  const ARegisterCount, AParamCount, AParam0Reg, AParam1Reg: UInt32;
+  const ACoreLabel, AExternalLabel: TWasmJitLabel);
+var
+  FrameBytes: UInt32;
+begin
+  { Canonical entries carry their non-nil context in rcx. A lightweight leaf
+    caller passes nil with scalar arguments in r8/r9 and receives r8. }
+  X64EmitAluRegReg(ABuf, $85, True, X64_RCX, X64_RCX);
+  X64EmitJccTo(ABuf, X64_CC_NE, UInt32(AExternalLabel));
+  FrameBytes := (ARegisterCount * X64_SLOT_SIZE + 15) and not UInt32(15);
+  X64EmitPushReg(ABuf, X64_RBX);
+  X64EmitSubRsp(ABuf, Int32(FrameBytes));
+  X64EmitMovRegReg(ABuf, X64_REG_REGFILE, X64_RSP);
+  { Keep the native frame canonical as well as register-cached. This makes the
+    bridge safe if an eligible operation uses a memory-backed template. }
+  X64EmitStoreSlot64(ABuf, X64_R8, AParam0Reg);
+  if AParamCount = 2 then
+    X64EmitStoreSlot64(ABuf, X64_R9, AParam1Reg);
+  X64EmitCallTo(ABuf, ACoreLabel);
+  X64EmitAddRsp(ABuf, Int32(FrameBytes));
+  X64EmitPopReg(ABuf, X64_RBX);
+  X64EmitRet(ABuf);
+end;
+
+procedure X64EmitNativeCoreWrapperCall(const ABuf: TWasmCodeBuffer;
+  const AParamCount, AParam0Reg, AParam1Reg, AResultReg: UInt32;
+  const ACoreLabel: TWasmJitLabel);
+begin
+  X64EmitLoadSlot64(ABuf, X64_R8, AParam0Reg);
+  if AParamCount = 2 then
+    X64EmitLoadSlot64(ABuf, X64_R9, AParam1Reg);
+  X64EmitCallTo(ABuf, ACoreLabel);
+  X64EmitStoreSlot64(ABuf, X64_R8, AResultReg);
 end;
 
 procedure X64EmitPinHelperTable(const ABuf: TWasmCodeBuffer;
@@ -2855,9 +2996,13 @@ begin
   X64EmitLoadMem64(ABuf, X64_REG_EPOCH, X64_REG_STORE, Int32(ASnapshotOffset));
 end;
 
-procedure X64EmitEpilogue(const ABuf: TWasmCodeBuffer);
+procedure X64EmitEpilogue(const ABuf: TWasmCodeBuffer;
+  const ARetainContext: Boolean);
 begin
-  X64EmitAddRsp(ABuf, 8);            { undo the alignment pad }
+  if ARetainContext then
+    X64EmitAddRsp(ABuf, 24)
+  else
+    X64EmitAddRsp(ABuf, 8);
   X64EmitPopReg(ABuf, X64_RBP);
   X64EmitPopReg(ABuf, X64_R15);
   X64EmitPopReg(ABuf, X64_R14);
@@ -3436,14 +3581,94 @@ begin
   end;
 end;
 
+procedure EmitNativeScalarLeafDirectCall(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
+  const AArgN: UInt32; const AFallback, ADone: TWasmJitLabel);
+var
+  FO: TWasmJitFrameOffsets;
+  FuncLayout: TWasmFuncInst;
+  FuncNativeEntry, MetaRegisterCount: UInt32;
+  Exhausted: TWasmJitLabel;
+begin
+  FO := WasmJitFrameOffsets;
+  FuncNativeEntry := UInt32(
+    PtrUInt(@FuncLayout.CompiledNativeScalarEntry) - PtrUInt(@FuncLayout));
+  MetaRegisterCount := UInt32(
+    PtrUInt(@FuncLayout.DirectMeta.RegisterCount) - PtrUInt(@FuncLayout));
+  Exhausted := ABuf.NewLabel;
+
+  { Resolve caller funcidx through the live activation address map. }
+  X64EmitLoadMem64(ABuf, X64_RAX, X64_RSP, 8);       { context }
+  X64EmitLoadMem64(ABuf, X64_RCX, X64_RAX, Int32(FO.CtxDepth));
+  X64EmitMovRegImm32(ABuf, X64_RSI, 1);
+  X64EmitAluRegReg(ABuf, $29, True, X64_RCX, X64_RSI);
+  X64EmitMovRegImm64(ABuf, X64_RSI, FO.ActStride);
+  X64EmitImul(ABuf, True, X64_RCX, X64_RSI);
+  X64EmitLoadMem64(ABuf, X64_RDX, X64_RAX, Int32(FO.CtxActs));
+  X64EmitAluRegReg(ABuf, $01, True, X64_RDX, X64_RCX);
+  X64EmitLoadMem64(ABuf, X64_RDX, X64_RDX, Int32(FO.ActFuncAddrs));
+  X64EmitLoadMem32(ABuf, X64_RCX, X64_RDX,
+    Int32(UInt32(AIns.Imm) * 4));
+  X64EmitLoadMem64(ABuf, X64_RDX, X64_RAX, Int32(FO.CtxFuncsSlot));
+  X64EmitLoadMem64(ABuf, X64_RDX, X64_RDX, 0);
+  X64EmitMovRegImm64(ABuf, X64_RSI, SizeOf(TWasmFuncInst));
+  X64EmitImul(ABuf, True, X64_RCX, X64_RSI);
+  X64EmitAluRegReg(ABuf, $01, True, X64_RDX, X64_RCX);
+  X64EmitLoadMem64(ABuf, X64_RAX, X64_RDX, Int32(FuncNativeEntry));
+  X64EmitAluRegReg(ABuf, $85, True, X64_RAX, X64_RAX);
+  X64EmitJccTo(ABuf, X64_CC_E, UInt32(AFallback));
+
+  { Match JitEnterResolvedFrame's depth and value-slot predicates before the
+    lightweight call mutates native stack state. }
+  X64EmitLoadMem64(ABuf, X64_RCX, X64_RSP, 8);
+  X64EmitLoadMem64(ABuf, X64_RSI, X64_RCX, Int32(FO.CtxDepth));
+  X64EmitLoadMem64(ABuf, X64_RDI, X64_RCX, Int32(FO.CtxDepthCap));
+  X64EmitAluRegReg(ABuf, $39, True, X64_RSI, X64_RDI);
+  X64EmitJccTo(ABuf, X64_CC_AE, UInt32(Exhausted));
+  X64EmitLoadMem64(ABuf, X64_RSI, X64_RCX, Int32(FO.CtxValueTop));
+  X64EmitLoadMem32(ABuf, X64_RDI, X64_RDX, Int32(MetaRegisterCount));
+  X64EmitAluRegReg(ABuf, $01, True, X64_RSI, X64_RDI);
+  X64EmitLoadMem64(ABuf, X64_RDI, X64_RCX, Int32(FO.CtxValueCap));
+  X64EmitAluRegReg(ABuf, $39, True, X64_RSI, X64_RDI);
+  X64EmitJccTo(ABuf, X64_CC_A, UInt32(Exhausted));
+
+  X64EmitLoadSlot64(ABuf, X64_R8,
+    IrAuxBlockItem(AAux, AIns.A, 0));
+  if AArgN = 2 then
+    X64EmitLoadSlot64(ABuf, X64_R9,
+      IrAuxBlockItem(AAux, AIns.A, 1));
+  X64EmitMovRegImm32(ABuf, X64_RCX, 0);              { native-leaf selector }
+  X64EmitCallReg(ABuf, X64_RAX);
+  X64EmitStoreSlot64(ABuf, X64_R8,
+    IrAuxBlockItem(AAux, AIns.B, 0));
+  X64EmitJmpTo(ABuf, UInt32(ADone));
+
+  ABuf.BindLabel(Exhausted);
+  X64EmitMovRegImm32(ABuf, X64_ARG0, UInt32(Ord(wtkStackExhausted)));
+  X64EmitCallHelper(ABuf, aohTrapKind);
+end;
+
 procedure EmitCall(const ABuf: TWasmCodeBuffer; const AIns: TWasmIrInstr;
-  const AAux: TWasmIrAuxU32);
+  const AAux: TWasmIrAuxU32; const AUseNativeScalarCall: Boolean);
 var
   ArgN, ResN, ArgBytes, ResBytes, StateOffset, FrameBytes: UInt32;
-  FallbackLabel, DoneLabel: TWasmJitLabel;
+  FallbackLabel, DoneLabel, NativeFallback, NativeDone: TWasmJitLabel;
+  UseNativeLeaf: Boolean;
 begin
   ArgN := IrAuxBlockCount(AAux, AIns.A);
   ResN := IrAuxBlockCount(AAux, AIns.B);
+  UseNativeLeaf := AUseNativeScalarCall and (AIns.Op = iroCall) and
+    (ArgN in [1, 2]) and (ResN = 1);
+  NativeFallback := -1;
+  NativeDone := -1;
+  if UseNativeLeaf then
+  begin
+    NativeFallback := ABuf.NewLabel;
+    NativeDone := ABuf.NewLabel;
+    EmitNativeScalarLeafDirectCall(ABuf, AIns, AAux, ArgN,
+      NativeFallback, NativeDone);
+    ABuf.BindLabel(NativeFallback);
+  end;
   ArgBytes := ArgN * X64_SLOT_SIZE;
   ResBytes := ResN * X64_SLOT_SIZE;
   StateOffset := ArgBytes + ResBytes;
@@ -3476,6 +3701,8 @@ begin
         X64EmitMovRegReg(ABuf, X64_ARG1, X64_REG_STORE);
         X64EmitLoadMem64(ABuf, X64_ARG2, X64_RSP,
           Int32(StateOffset + X64_SLOT_SIZE));
+        X64EmitLoadMem64(ABuf, X64_ARG3, X64_RSP,
+          Int32(StateOffset + 2 * X64_SLOT_SIZE));
         X64EmitCallReg(ABuf, X64_R11);
         if (ArgN = 1) and (ResN = 1) then
         begin
@@ -3522,10 +3749,12 @@ begin
 
   EmitUnmarshalResults(ABuf, AAux, AIns.B, ResN, ArgBytes);
   X64EmitAddRsp(ABuf, Int32(FrameBytes));
+  if UseNativeLeaf then
+    ABuf.BindLabel(NativeDone);
 end;
 
 procedure EmitReturnCall(const ABuf: TWasmCodeBuffer; const AIns: TWasmIrInstr;
-  const AAux: TWasmIrAuxU32);
+  const AAux: TWasmIrAuxU32; const ARetainContext: Boolean);
 var
   ArgN, FrameBytes: UInt32;
 begin
@@ -3561,7 +3790,7 @@ begin
   end;
 
   X64EmitAddRsp(ABuf, Int32(FrameBytes));
-  X64EmitEpilogue(ABuf);
+  X64EmitEpilogue(ABuf, ARetainContext);
 end;
 
 { ===================================================================== }
@@ -3718,7 +3947,8 @@ end;
 
 function X64EmitOp(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
-  const AInsIndex: UInt32): Boolean;
+  const AInsIndex: UInt32; const ARetainContext,
+  AUseNativeScalarCall: Boolean): Boolean;
 begin
   Result := True;
   case AIns.Op of
@@ -3750,12 +3980,13 @@ begin
         X64EmitJccTo(ABuf, X64_CC_E, AIns.B);
       end;
     iroBrTable: EmitBrTable(ABuf, AIns, AAux);
-    iroReturn: X64EmitEpilogue(ABuf);
+    iroReturn: X64EmitEpilogue(ABuf, ARetainContext);
     iroUnreachable: EmitTrapCall(ABuf, wtkUnreachable);
 
-    iroCall, iroCallIndirect, iroCallRef: EmitCall(ABuf, AIns, AAux);
+    iroCall, iroCallIndirect, iroCallRef:
+      EmitCall(ABuf, AIns, AAux, AUseNativeScalarCall);
     iroReturnCall, iroReturnCallIndirect, iroReturnCallRef:
-      EmitReturnCall(ABuf, AIns, AAux);
+      EmitReturnCall(ABuf, AIns, AAux, ARetainContext);
 
     iroSelect: EmitSelect(ABuf, AIns);
 

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -365,7 +365,7 @@ var
   HasSelfCall: Boolean;
 begin
   Result := False;
-  {$IFDEF WASM_JIT_ARM64}
+  {$IFDEF WASM_JIT_BACKEND}
   if (AFn = nil) or (AFn^.ParamCount <> 1) or (AFn^.ResultCount <> 1) or
     (Length(AFn^.LocalRegs) <> 1) or (Length(AFn^.ResultRegs) <> 1) or
     (Length(AFn^.EntryZeroRegs) <> 0) or (Length(AFn^.Handlers) <> 0) or
@@ -489,6 +489,7 @@ var
   UseNativeScalarLeaf: Boolean;
   UseNativeScalarCore: Boolean;
   UseNativeScalarCall: Boolean;
+  UseX64ExtendedFrame: Boolean;
   NativeScalarCall: Boolean;
   UseExtendedFrame: Boolean;
   NativeParamCount: UInt32;
@@ -1557,6 +1558,7 @@ begin
         NativeParam1Reg, UseNativeScalarLeaf and not UseNativeScalarSelf);
     {$ENDIF}
     {$IFDEF WASM_JIT_X64}
+    UseX64ExtendedFrame := UseNativeScalarCall or UseNativeScalarSelf;
     if UseNativeScalarLeaf then
     begin
       X64EmitNativeLeafEntry(Buf, AFn^.RegisterCount, NativeParamCount,
@@ -1564,22 +1566,24 @@ begin
         NativeExternalLabel);
       Buf.BindLabel(NativeExternalLabel);
     end;
-    X64EmitPrologue(Buf, UseNativeScalarCall);
+    X64EmitPrologue(Buf, UseX64ExtendedFrame);
     X64EmitPinHelperTable(Buf, AHelperTableOffset);
     X64EmitEpochCapture(Buf, AEpochOffset, ASnapshotOffset);
+    if UseNativeScalarSelf then
+      X64EmitNativeSelfBudget(Buf, AFn^.RegisterCount);
     if UsePinnedMemory then
       X64EmitPinMemory(Buf, PinnedMemoryIndex);
     X64InitRegCache(X64Cache);
-    if UseNativeScalarLeaf then
+    if UseNativeScalarCore then
       X64SeedNativeCoreCache(X64Cache, NativeParamCount, NativeParamReg,
-        NativeParam1Reg)
+        NativeParam1Reg, UseNativeScalarLeaf)
     else if UseStaticCache then
       X64EnableStaticRegCache(Buf, X64Cache, AllocatedSlots);
-    if UseNativeScalarLeaf then
+    if UseNativeScalarCore then
     begin
       X64EmitNativeCoreWrapperCall(Buf, NativeParamCount, NativeParamReg,
         NativeParam1Reg, NativeResultReg, NativeCoreLabel);
-      X64EmitEpilogue(Buf, UseNativeScalarCall);
+      X64EmitEpilogue(Buf, UseX64ExtendedFrame);
       Buf.BindLabel(NativeCoreLabel);
     end;
     {$ENDIF}
@@ -1648,8 +1652,10 @@ begin
           (AFn^.Code[I].A < UInt32(Length(AFn^.RegTypes))) and
             (AFn^.RegTypes[AFn^.Code[I].A].Kind = wvkNum) and
             (AFn^.RegTypes[AFn^.Code[I].A].Num = wntI64),
-          UsePinnedMemory, UseNativeScalarLeaf, NativeResultReg,
-          UseNativeScalarCall, NativeScalarCall,
+          UsePinnedMemory, UseNativeScalarCore, UseNativeScalarSelf,
+          AFn^.RegisterCount, NativeParamReg, NativeResultReg,
+          NativeCoreLabel, NativeExhaustedLabel, UseX64ExtendedFrame,
+          NativeScalarCall,
           X64Cache);
       {$ENDIF}
       if not Emitted then
@@ -1673,6 +1679,12 @@ begin
     Arm64ResolvePatches(Buf);
     {$ENDIF}
     {$IFDEF WASM_JIT_X64}
+    if UseNativeScalarSelf then
+    begin
+      Buf.BindLabel(NativeExhaustedLabel);
+      X64EmitMovRegImm32(Buf, X64_ARG0, UInt32(Ord(wtkStackExhausted)));
+      X64EmitCallHelper(Buf, aohTrapKind);
+    end;
     X64ResolvePatches(Buf);
     {$ENDIF}
     { AOT staging (aot-spec §3.2) stops HERE, before MakeExecutable: the caller

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -158,12 +158,11 @@ type
     property Store: TWasmStore read FStore;
   end;
 
-  { The x64 / backend-free compiled-entry declaration. It receives the
+  { The backend-free compiled-entry declaration. It receives the
     register-file base pointer JitEnterFrame returned (@Values[Base]), the
     store, and the IR-code base @Fn^.Code[0]. The AArch64 backend extends this
-    private ABI with the interpreter context used by generated direct-call
-    frame setup and an entry pointer retained by the generic direct-call ABI;
-    its local declaration is fingerprinted with the AOT ABI.
+    private ABI with additional generated-call state; each backend's local
+    declaration is fingerprinted with the AOT ABI.
     cdecl selects the platform C convention, matching each backend's
     hand-emitted prologue/epilogue. }
   TWasmJitCompiledEntry = procedure(const ARegBase: PWasmValue;
@@ -190,7 +189,8 @@ function JitCanCompile(const AFn: PWasmIrFunctionRec): Boolean;
 function JitCanNativeScalarSelf(const AFn: PWasmIrFunctionRec;
   const ASelfFuncIdx: UInt32): Boolean;
 
-{ A bounded cross-function companion: a one/two-parameter, one-result numeric
+{ A bounded cross-function companion for both native backends: a
+  one/two-parameter, one-result numeric
   leaf whose body cannot trap, allocate, call, or reach a safepoint. It may use
   a lightweight native-stack frame because no operation inside it can observe
   the temporarily unpublished logical frame. }
@@ -215,6 +215,10 @@ function JitStageFunctionBytes(const AStore: TWasmStore;
 function JitStageFunctionBytes(const AStore: TWasmStore;
   const AFn: PWasmIrFunctionRec; const AFuncIdx: UInt32;
   out AEntryOffset: NativeUInt;
+  out ARegisterCount: UInt32): TWasmBytes; overload;
+function JitStageFunctionBytes(const AStore: TWasmStore;
+  const AIr: TWasmIrModule; const AFn: PWasmIrFunctionRec;
+  const AFuncIdx: UInt32; out AEntryOffset: NativeUInt;
   out ARegisterCount: UInt32): TWasmBytes; overload;
 
 implementation
@@ -278,8 +282,7 @@ var
   IrBase: PWasmIrInstr;
 begin
   { No backend on this target, so nothing is ever compiled and this is
-    unreachable; kept as the plain single-shot hand-off so the unit still
-    compiles and documents the x64 (3-arg, position-independent) contract. }
+    unreachable; kept as the plain single-shot hand-off. }
   Ctx := InterpContextFor(AStore);
   Base := JitEnterFrame(Ctx, AStore, AFuncAddr, AParams, AResults,
     ConsumeJitSeamReentry);
@@ -409,7 +412,7 @@ var
   I: Integer;
 begin
   Result := False;
-  {$IFDEF WASM_JIT_ARM64}
+  {$IFDEF WASM_JIT_BACKEND}
   if (AFn = nil) or (AFn^.ParamCount < 1) or (AFn^.ParamCount > 2) or
     (AFn^.ResultCount <> 1) or
     (Length(AFn^.LocalRegs) <> Integer(AFn^.ParamCount)) or
@@ -455,7 +458,8 @@ end;
   made executable. iroReturn emits the epilogue, so the prologue's saves are
   always balanced by a restore. The Arm64* / X64* calls are the only
   backend-specific part; everything else is shared. }
-function JitCompileToBuffer(const AFn: PWasmIrFunctionRec;
+function JitCompileToBuffer(const AIr: TWasmIrModule;
+  const AFn: PWasmIrFunctionRec;
   const AFuncIdx: UInt32;
   const AEpochOffset, ASnapshotOffset, AHelperTableOffset: NativeUInt;
   const AFinalize: Boolean = True): TWasmCodeBuffer;
@@ -484,6 +488,8 @@ var
   UseNativeScalarSelf: Boolean;
   UseNativeScalarLeaf: Boolean;
   UseNativeScalarCore: Boolean;
+  UseNativeScalarCall: Boolean;
+  NativeScalarCall: Boolean;
   UseExtendedFrame: Boolean;
   NativeParamCount: UInt32;
   NativeParamReg: UInt32;
@@ -547,6 +553,19 @@ var
   end;
 
   function IsVisibleFrameReg(const AReg: UInt32): Boolean; forward;
+
+  function NativeScalarLeafTarget(const AFuncIdx: UInt32): Boolean;
+  var
+    DefinedIdx: UInt32;
+  begin
+    Result := False;
+    if (AIr = nil) or (AFuncIdx < AIr.FuncImportCount) then
+      Exit;
+    DefinedIdx := AFuncIdx - AIr.FuncImportCount;
+    if DefinedIdx >= UInt32(Length(AIr.Functions)) then
+      Exit;
+    Result := JitCanNativeScalarLeaf(@AIr.Functions[DefinedIdx]);
+  end;
 
   procedure AnalyzeAdjacentMoves;
   var
@@ -1408,6 +1427,7 @@ begin
     UseNativeScalarSelf := JitCanNativeScalarSelf(AFn, AFuncIdx);
     UseNativeScalarLeaf := JitCanNativeScalarLeaf(AFn);
     UseNativeScalarCore := UseNativeScalarSelf or UseNativeScalarLeaf;
+    UseNativeScalarCall := False;
     NativeParamCount := 0;
     NativeParamReg := 0;
     NativeParam1Reg := 0;
@@ -1442,6 +1462,10 @@ begin
       no generated flush is needed. }
     SetLength(Targets, Length(AFn^.Code));
     for I := 0 to High(AFn^.Code) do
+    begin
+      if (AFn^.Code[I].Op = iroCall) and
+        NativeScalarLeafTarget(UInt32(AFn^.Code[I].Imm)) then
+        UseNativeScalarCall := True;
       case AFn^.Code[I].Op of
         iroJump: MarkTarget(AFn^.Code[I].A);
         iroBranchIf, iroBranchIfNot,
@@ -1455,6 +1479,7 @@ begin
                 UInt32(J)));
           end;
       end;
+    end;
 
     AnalyzePinnedMemory;
     AnalyzeStaticCache;
@@ -1532,14 +1557,31 @@ begin
         NativeParam1Reg, UseNativeScalarLeaf and not UseNativeScalarSelf);
     {$ENDIF}
     {$IFDEF WASM_JIT_X64}
-    X64EmitPrologue(Buf);
+    if UseNativeScalarLeaf then
+    begin
+      X64EmitNativeLeafEntry(Buf, AFn^.RegisterCount, NativeParamCount,
+        NativeParamReg, NativeParam1Reg, NativeCoreLabel,
+        NativeExternalLabel);
+      Buf.BindLabel(NativeExternalLabel);
+    end;
+    X64EmitPrologue(Buf, UseNativeScalarCall);
     X64EmitPinHelperTable(Buf, AHelperTableOffset);
     X64EmitEpochCapture(Buf, AEpochOffset, ASnapshotOffset);
     if UsePinnedMemory then
       X64EmitPinMemory(Buf, PinnedMemoryIndex);
     X64InitRegCache(X64Cache);
-    if UseStaticCache then
+    if UseNativeScalarLeaf then
+      X64SeedNativeCoreCache(X64Cache, NativeParamCount, NativeParamReg,
+        NativeParam1Reg)
+    else if UseStaticCache then
       X64EnableStaticRegCache(Buf, X64Cache, AllocatedSlots);
+    if UseNativeScalarLeaf then
+    begin
+      X64EmitNativeCoreWrapperCall(Buf, NativeParamCount, NativeParamReg,
+        NativeParam1Reg, NativeResultReg, NativeCoreLabel);
+      X64EmitEpilogue(Buf, UseNativeScalarCall);
+      Buf.BindLabel(NativeCoreLabel);
+    end;
     {$ENDIF}
 
     for I := 0 to High(AFn^.Code) do
@@ -1592,6 +1634,8 @@ begin
       end;
       {$ENDIF}
       {$IFDEF WASM_JIT_X64}
+      NativeScalarCall := (AFn^.Code[I].Op = iroCall) and
+        NativeScalarLeafTarget(UInt32(AFn^.Code[I].Imm));
       if Fusion[I] >= 0 then
       begin
         X64EmitCompareBranchCached(Buf, PlannedCode[Fusion[I]],
@@ -1604,7 +1648,8 @@ begin
           (AFn^.Code[I].A < UInt32(Length(AFn^.RegTypes))) and
             (AFn^.RegTypes[AFn^.Code[I].A].Kind = wvkNum) and
             (AFn^.RegTypes[AFn^.Code[I].A].Num = wntI64),
-          UsePinnedMemory,
+          UsePinnedMemory, UseNativeScalarLeaf, NativeResultReg,
+          UseNativeScalarCall, NativeScalarCall,
           X64Cache);
       {$ENDIF}
       if not Emitted then
@@ -1742,7 +1787,7 @@ begin
     then stays interpreted, which is always correct (jit-spec §4.3). Any other
     exception is a genuine internal fault and propagates. }
   try
-    FBuffers[N] := JitCompileToBuffer(Fn,
+    FBuffers[N] := JitCompileToBuffer(FStore.Funcs[AAddr].Instance.Ir, Fn,
       FStore.Funcs[AAddr].Instance.Ir.FuncImportCount +
         FStore.Funcs[AAddr].FuncIrIndex,
       WasmJitOffsets(FStore).StoreEpoch,
@@ -1852,6 +1897,15 @@ function JitStageFunctionBytes(const AStore: TWasmStore;
   const AFn: PWasmIrFunctionRec; const AFuncIdx: UInt32;
   out AEntryOffset: NativeUInt;
   out ARegisterCount: UInt32): TWasmBytes;
+begin
+  Result := JitStageFunctionBytes(AStore, nil, AFn, AFuncIdx, AEntryOffset,
+    ARegisterCount);
+end;
+
+function JitStageFunctionBytes(const AStore: TWasmStore;
+  const AIr: TWasmIrModule; const AFn: PWasmIrFunctionRec;
+  const AFuncIdx: UInt32; out AEntryOffset: NativeUInt;
+  out ARegisterCount: UInt32): TWasmBytes;
 {$IFDEF WASM_JIT_BACKEND}
 var
   Buf: TWasmCodeBuffer;
@@ -1865,7 +1919,7 @@ begin
   ARegisterCount := AFn^.RegisterCount;
   {$IFDEF WASM_JIT_BACKEND}
   try
-    Buf := JitCompileToBuffer(AFn, AFuncIdx,
+    Buf := JitCompileToBuffer(AIr, AFn, AFuncIdx,
       WasmJitOffsets(AStore).StoreEpoch,
       WasmJitOffsets(AStore).StoreEpochSnapshot,
       WasmJitOffsets(AStore).StoreJitHelperTable, { AFinalize } False);

--- a/source/units/Wasm.Runtime.Store.pas
+++ b/source/units/Wasm.Runtime.Store.pas
@@ -302,8 +302,9 @@ type
       and re-dispatches its pending target. }
     CompiledDirectEntry: Pointer;
     { Same entry address for a proof-gated one/two-parameter numeric leaf. A
-      zero x4 selects its lightweight native-stack ABI; ordinary entries pass
-      the non-zero canonical address and retain the published logical frame. }
+      zero selector (x4 on Arm64, rcx on x64) chooses its lightweight native-
+      stack ABI; ordinary entries pass a non-zero context/address selector and
+      retain the published logical frame. }
     CompiledNativeScalarEntry: Pointer;
     CallCount: UInt32;
     DirectMeta: TWasmDirectCallMeta;


### PR DESCRIPTION
## Summary

- add a proof-gated x64 native scalar entry/core ABI for eligible one- and two-argument numeric leaf calls while retaining the generic compiled, interpreted, and host fallback
- specialize eligible one-argument scalar self-recursion with exact shared depth/value budgeting and no invented epoch safepoints
- preserve SysV stack alignment, tail-call frame restoration, parameter/cache coherence, PIC/AOT loading, and reject stale artifacts with AOT ABI revision 14
- add focused x64 and cross-tier regressions for tail exits, select/rotate, `local.set`, exact exhaustion cleanup, sequential recursive calls, JIT, and loaded AOT

## Performance

Serialized OrbStack x64 AOT A/B used fresh self-checking processes, compilation outside timing, one warm-up plus seven samples per binary and order, and the shared performance lock.

- 50 million eligible scalar leaf calls: 7146.799 -> 1905.832 ms forward and 5540.303 -> 1487.807 ms reverse, 73.33% and 73.15% faster
- recursive fib: 2984.799 -> 533.784 ms forward and 2982.862 -> 534.782 ms reverse, 82.12% and 82.07% faster
- ordinary calls, ineligible-call fallback, loop, memory, and startup guards remained flat within measurement spread

These are same-VM A/B measurements on OrbStack virtualized amd64 over an Arm host, not native x64 hardware claims. Two intermediate candidates with repeatable fallback or memory regressions were rejected before acceptance.

## Readiness

- this is an x64 baseline-JIT/AOT code-generation optimization over the existing validated IR; validation, interpreter semantics, the tier seam, and error classes are unchanged
- interpreter/JIT/AOT corpus identity verifies observational equivalence; ineligible, trapping, host, indirect, and reference-bearing calls remain on the existing generic path
- host capability and sandbox policy are unchanged, and no dependency is added
- this ports the already accepted Arm64 scalar-call architecture to x64 and does not create or reverse an architectural decision, so no ADR is required
- the measured hot-path specialization and all rejected candidates are recorded in `.agent/HANDOFF.md`

## Testing

- `lwpt install --frozen`
- `lwpt format --check`
- `lwpt agents --check`
- clean release and development builds: 3/3 each
- `lwpt test`: 44 passed, 0 failed, 0 skipped
- `npx --yes markdownlint-cli2@0.18.1 '**/*.md'`: 43 files, 0 errors
- macOS pinned core corpus at `de54fd27`, interpreter/JIT/AOT: 65,188 pass, 0 fail, 0 skip, 0 staged, 0 errors; JIT/AOT compiled 8,703 functions
- fresh OrbStack Linux x86-64 archive, FPC 3.2.2 and checksum-verified LWPT 0.6.0: the same 65,188/0/0/0 tier identity; x64 JIT/AOT compiled 8,704 functions

## Linked issues

Follow-up x64 optimization work after #6. No issue is closed by this PR.
