### PR TITLE
chore(release): finalize 0.1.0 documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 All notable changes to wasmlight are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); entries are generated from Conventional Commits by git-cliff.
+
 ## [0.1.0] - 2026-08-15
 
 ### Bug Fixes

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,6 +14,7 @@ header = """
 All notable changes to wasmlight are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); entries are generated from Conventional Commits by git-cliff.
 """
 body = """
+{{ "\n" -}}
 {% if version -%}
   ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,9 +2,9 @@
 
 ## Executive Summary
 
-- Nothing is released yet. wasmlight is pre-0.1; this file records the
-  intended release mechanics so the first release follows them rather
-  than inventing them.
+- `0.1.0` is wasmlight's first release: the completed pinned-Core-3 runtime,
+  its three execution tiers on 64-bit UNIX, the interpreter on every supported
+  target, and the current deny-by-default WASI Preview 1 subset.
 - Releases go through the `create-release` skill: changelog first, then
   an unprefixed SemVer tag matching `[package].version` in `lwpt.toml`.
 - wasmlight is consumed as an lwpt dependency, not as a distributed
@@ -31,8 +31,8 @@ The gates are in [DEFINITION_OF_DONE.md](../DEFINITION_OF_DONE.md); the
 mechanics are:
 
 1. `ci.yml` is green on the release commit — the full platform matrix.
-2. Bump `[package].version` in `lwpt.toml`. That is the single source of
-   truth: the `prebuild` hook restamps `source/units/Version.inc`, so
+2. Set and verify `[package].version` in `lwpt.toml`. That is the single source
+   of truth: the `prebuild` hook restamps `source/units/Version.inc`, so
    `wasmlight --version` follows automatically.
 3. Regenerate the changelog with git-cliff and land it **before** the tag,
    so the tag's notes are published from a committed section.


### PR DESCRIPTION
## Summary

- describe 0.1.0 as the first release instead of leaving deployment documentation at pre-release state
- make the release checklist confirm the authoritative manifest version
- fix git-cliff output so the generated changelog has a valid heading boundary and exactly one final newline

## Testing

- git cliff --tag 0.1.0 -o CHANGELOG.md
- lwpt install --frozen
- lwpt format --check
- lwpt agents --check
- lwpt build — 3 built, 0 failed
- lwpt test — 44 passed, 0 failed, 0 skipped
- npx markdownlint-cli2 "**/*.md" — 0 issues
- git diff --check

## Release boundary

This is a corrective continuation of #8 discovered by the required post-merge reread. It adds no release content or runtime behavior; both commits use the release subject and are excluded by the committed git-cliff rules, so the generated 0.1.0 section remains complete before tagging.
