### PR TITLE
perf(jit): emit v128 moves and consts natively on arm64 and x64

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,57 @@
 # Handoff
 
+Updated: 2026-08-21 (native v128 move/const emission, both backends)
+
+## v128 helper-crossing elimination
+
+- Branch `codex/optimize-profile-driven` from exact
+  `origin/main@8a01d6ecec2f0569daefa61068f8bdb4078d44ac`. Accepted commits:
+  `0ad4959` (`perf(jit): emit v128 moves and consts natively on arm64`) and
+  `6a8c238` (`perf(jit): emit v128 moves and consts natively on x64`).
+  Delivery not requested; the branch is local and unpushed.
+- Profile-driven target selection. Serialized wasmbench baseline (release,
+  7 samples) at the exact starting commit showed compiled-tier SIMD as the
+  outlier (127 ns/op). A `sample(1)` profile of a 20M-iteration simd jit run
+  attributed the samples to `InterpContextFor` (82), `_platform_memmove` +
+  `FPC_MOVE` (~109), and generated-code helper regions. Mechanism: every
+  `iroMoveVec` (v128 local.get/set/tee) and `iroV128Const` paid the full
+  `JitVecDispatch` crossing — native call, activation lookup, ~200-arm case
+  dispatch, 16-byte record copy — despite the arithmetic ops already being
+  native. Vector-bearing loops execute ~10+ such crossings per iteration.
+- Lane A (Arm64, `0ad4959`): `iroMoveVec` emits one Q-register LDR/STR pair;
+  `iroV128Const` reads its bits from the aux block at compile time and bakes
+  two movz/movk immediates into the destination slot pair. Everything else
+  keeps the helper fallback; no new helpers, no ABI change, no scope-fence
+  change. macOS/aarch64 serialized A/B (one warm-up discarded, 7 samples,
+  BASE-CAND-CAND-BASE under `/tmp/wasmlight-perf-gate.lock`): simd jit
+  126/126 -> 69/69 ms and simd aot 126/126 -> 69/69 ms (-45%); loop, fib,
+  memory, numeric guards flat; startup inside noise.
+- Lane B (x64, `6a8c238`): mirror shape — MOVDQU load/store pair for the
+  move; two movabs/MOVQ halves joined by PUNPCKLQDQ for the const.
+  x86-64 evidence from OrbStack `wasmx64` (virtualized amd64 over an Arm
+  host — same-VM A/B evidence, not a native hardware claim): simd jit
+  1432/1457 -> 455/469 ms (-68%) and simd aot 1117/1117 -> 342/342 ms
+  (-69%); loop, fib, memory, numeric guards flat.
+- Correctness: all 44 unit suites pass on macOS/aarch64 and Linux/x86-64
+  (LWPT 0.6.0 explicit binary at `/tmp/lwpt-0.6.0.Uq7icT/lwpt-0.6.0-linux-x64/`,
+  never the stale VM-PATH 0.4.0). The recursive 288-script corpus at
+  `de54fd27` is byte-identical across interpreter/JIT/AOT before and after:
+  pass=65851 fail=368 skip=904 staged=0 errors=0 (compiled=8799 aarch64,
+  8800 x86-64). Frozen install, format, agents check, dev + release builds,
+  and Markdown lint pass on the combined head.
+- Operational notes for future waves: macOS has no `flock` — use the
+  mkdir-based `/tmp/wasmlight-perf-gate.lock` directory lock; a stale plain
+  file of that name existed on BOTH hosts (VM one dated Aug 15) and silently
+  blocked acquisition until removed. macOS bsdtar archives sprout AppleDouble
+  `._*` files when extracted by GNU tar — delete them before running
+  `wasmspec` or every file double-counts as an error.
+- Remaining profiled bottlenecks for a later wave: GC allocation (~4.4x
+  Wasmtime on the bounded-live-set workload) and scalar memory load/store
+  (~1.4x); the SIMD gap that motivated this wave closed to within roughly
+  2.2x on the wasmbench shape (69 vs ~30 ns/op equivalent) with the residual
+  being the remaining helper-dispatched vector forms (comparisons, shifts,
+  min/max, narrowing) rather than moves or consts.
+
 Updated: 2026-08-15 (post-v1 roadmap and 0.1.0 release)
 
 ## Durable roadmap and release decisions

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -5143,6 +5143,12 @@ begin
   Arm64EmitCallHelper(ABuf, aohVecDispatch);
 end;
 
+{ iroMoveVec and iroV128Const join the native subset because they dominate
+  vector-bearing loops' helper traffic: every v128 local.get/set/tee lowers to
+  a move and every literal to a const, and each used to pay the full dispatch
+  crossing for what is one Q-register copy or two immediate stores. The const
+  bits are read from the aux block at COMPILE time and baked as movz/movk
+  pairs, so no run-time aux reach is needed. }
 function Arm64NativeVecOp(const AOp: TWasmIrOp): Boolean;
 begin
   case AOp of
@@ -5152,7 +5158,8 @@ begin
     iroI8x16Splat, iroI16x8Splat, iroI32x4Splat, iroI64x2Splat,
     iroI8x16ExtractLaneS, iroI8x16ExtractLaneU,
     iroI16x8ExtractLaneS, iroI16x8ExtractLaneU,
-    iroI32x4ExtractLane, iroI64x2ExtractLane:
+    iroI32x4ExtractLane, iroI64x2ExtractLane,
+    iroMoveVec, iroV128Const:
       Result := True;
   else
     Result := False;
@@ -5201,9 +5208,24 @@ begin
 end;
 
 procedure EmitNativeVec(const ABuf: TWasmCodeBuffer;
-  const AIns: TWasmIrInstr);
+  const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32);
+var
+  VTmp: TWasmV128;
 begin
   case AIns.Op of
+    iroMoveVec:
+      begin
+        LdQ(ABuf, 0, AIns.A);
+        StQ(ABuf, 0, AIns.Dest);
+      end;
+    iroV128Const:
+      begin
+        IrAuxReadV128(AAux, UInt32(AIns.Imm), VTmp);
+        Arm64EmitLoadImm64(ABuf, ARM64_REG_T0, VTmp.U64[0]);
+        StX(ABuf, ARM64_REG_T0, AIns.Dest);
+        Arm64EmitLoadImm64(ABuf, ARM64_REG_T1, VTmp.U64[1]);
+        StX(ABuf, ARM64_REG_T1, AIns.Dest + 1);
+      end;
     iroV128Not:
       begin
         LdQ(ABuf, 0, AIns.A);
@@ -5660,7 +5682,7 @@ begin
 
   else
     if Arm64NativeVecOp(AIns.Op) then
-      EmitNativeVec(ABuf, AIns)
+      EmitNativeVec(ABuf, AIns, AAux)
     else if Arm64LeafBinaryOp(AIns.Op) then
       EmitLeafBinary(ABuf, AIns)
     else if Arm64LeafUnaryOp(AIns.Op) then

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -1113,6 +1113,54 @@ begin
   ]);
 end;
 
+{ v128 local traffic: every function is dominated by v128.const and
+  local.set/get/tee — the two ops the backends lower natively as register
+  moves and baked immediates rather than the vector-helper dispatch. The
+  const bits are chosen so each lane pair differs, so a wrong half of a
+  baked immediate or a mis-addressed slot copy cannot cancel out. }
+function SimdLocalsModuleBytes: TWasmBytes;
+begin
+  Result := Cat([
+    BLit(WASM_HEADER),
+    Sect(1, VecOf([
+      BLit([$60, $00, $01, $7F]),                    { 0: ()->i32 }
+      BLit([$60, $01, $7F, $01, $7F])])),            { 1: (i32)->i32 }
+    Sect(3, VecOf([BLit([$00]), BLit([$00]), BLit([$01]),
+      BLit([$01])])),
+    Sect(7, VecOf([
+      ExportEntry('setget', $00, 0),
+      ExportEntry('tee', $00, 1),
+      ExportEntry('move', $00, 2),
+      ExportEntry('move2', $00, 3)])),
+    Sect(10, VecOf([
+      { const -> local.set -> local.get -> extract lane 2 = 0x08090A0B }
+      CodeEntry(Cat([BLit([$01, $01, $7B]), Fd(12),
+        V16([$00, $01, $02, $03, $04, $05, $06, $07,
+        $08, $09, $0A, $0B, $0C, $0D, $0E, $0F]),
+        BLit([$21, $00]), BLit([$20, $00]), Fd(27), BLit([$02, $0B])])),
+      { const all-EE -> local.tee keeps the value -> extract lane 1 }
+      CodeEntry(Cat([BLit([$01, $01, $7B]), Fd(12), V16([$EE, $EE]),
+        BLit([$22, $00]), Fd(27), BLit([$01, $0B])])),
+      { splat param into the local after a const occupied it: the move
+        overwrites both slots; extract lane 3 = param }
+      CodeEntry(Cat([BLit([$01, $01, $7B]), Fd(12),
+        V16([$10, $20, $30, $40, $50, $60, $70, $80,
+        $90, $A0, $B0, $C0, $D0, $E0, $F0, $01]),
+        BLit([$21, $01]), BLit([$20, $00]), Fd(17),
+        BLit([$21, $01]), BLit([$20, $01]), Fd(27), BLit([$03, $0B])])),
+      { move BETWEEN locals: local1 gets the const, local2 gets
+        splat(param) with lane 2 replaced by param again, result reads
+        local2 lane 2 = param }
+      CodeEntry(Cat([BLit([$02, $01, $7B, $01, $7B]), Fd(12),
+        V16([$11, $22, $33, $44, $55, $66, $77, $88,
+        $99, $AA, $BB, $CC, $DD, $EE, $FF, $07]),
+        BLit([$21, $01]), BLit([$20, $00]), Fd(17), BLit([$20, $00]),
+        Fd(28), BLit([$02]),
+        BLit([$21, $02]), BLit([$20, $02]), Fd(27), BLit([$02, $0B])]))
+    ]))
+  ]);
+end;
+
 { v128 float ops whose identity is the whole point: a NaN through f32x4.add
   (canonical-NaN bits), and pmin/pmax/relaxed_min (payload-preserving / R=0
   selection). Signatures take f32 params carrying the exact bit patterns. }
@@ -1426,6 +1474,7 @@ type
 
     { --- Wave 6: v128 SIMD via the Wasm.Interp.Vector leaves --------- }
     procedure TestSimdCompute;
+    procedure TestSimdLocalsMoveConst;
     procedure TestSimdFloatNanPminRelaxed;
     procedure TestSimdMemory;
     procedure TestSimdMemoryOob;
@@ -3316,6 +3365,22 @@ begin
     [])).ToBe(VEC_COMPILED);
 end;
 
+procedure TJitTests.TestSimdLocalsMoveConst;
+begin
+  { v128.const and v128 local.set/get/tee are lowered natively by both
+    compiling tiers (baked immediates and register-slot moves); the
+    differential proves the compiled results stay bit-identical to the
+    interpreter through every moved/overwritten slot pair. }
+  Expect<Boolean>(DiffModule(SimdLocalsModuleBytes, 'setget',
+    [])).ToBe(VEC_COMPILED);
+  Expect<Boolean>(DiffModule(SimdLocalsModuleBytes, 'tee',
+    [])).ToBe(VEC_COMPILED);
+  Expect<Boolean>(DiffModule(SimdLocalsModuleBytes, 'move',
+    [MakeValueI32($12345678)])).ToBe(VEC_COMPILED);
+  Expect<Boolean>(DiffModule(SimdLocalsModuleBytes, 'move2',
+    [MakeValueI32($76543210)])).ToBe(VEC_COMPILED);
+end;
+
 procedure TJitTests.TestSimdFloatNanPminRelaxed;
 begin
   { THE IDENTITY PROPERTY. A NaN through f32x4.add must yield the interpreter's
@@ -3487,6 +3552,8 @@ begin
 
   Test('v128 const/splat/extract/replace/add/eq/shuffle/swizzle match',
     TestSimdCompute);
+  Test('v128 consts and local set/get/tee move natively and match',
+    TestSimdLocalsMoveConst);
   Test('v128 NaN canonicalisation, pmin/pmax, and a relaxed op match per lane',
     TestSimdFloatNanPminRelaxed);
   Test('v128 load/store round-trip through the chokepoint matches',

--- a/source/units/Wasm.Jit.X64.pas
+++ b/source/units/Wasm.Jit.X64.pas
@@ -3511,6 +3511,10 @@ begin
   X64EmitCallHelper(ABuf, aohVecDispatch);
 end;
 
+{ iroMoveVec and iroV128Const join the native subset for the same reason as
+  the Arm64 backend: they dominate vector-bearing loops' helper traffic, and
+  a move is one MOVDQU pair while a const bakes its compile-time aux bits as
+  two movabs/MOVQ halves joined by PUNPCKLQDQ. }
 function X64NativeVecOp(const AOp: TWasmIrOp): Boolean;
 begin
   case AOp of
@@ -3520,7 +3524,8 @@ begin
     iroI8x16Splat, iroI16x8Splat, iroI32x4Splat, iroI64x2Splat,
     iroI8x16ExtractLaneS, iroI8x16ExtractLaneU,
     iroI16x8ExtractLaneS, iroI16x8ExtractLaneU,
-    iroI32x4ExtractLane, iroI64x2ExtractLane:
+    iroI32x4ExtractLane, iroI64x2ExtractLane,
+    iroMoveVec, iroV128Const:
       Result := True;
   else
     Result := False;
@@ -3556,9 +3561,37 @@ begin
 end;
 
 procedure EmitNativeVec(const ABuf: TWasmCodeBuffer;
-  const AIns: TWasmIrInstr);
+  const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32);
+var
+  VTmp: TWasmV128;
+
+  procedure EmitMovQXmmFromReg(const AXmm, AReg: Byte);
+  begin
+    { MOVQ xmm, r64 = 66 REX.W 0F 6E /r }
+    ABuf.EmitByte($66);
+    X64EmitRex(ABuf, 1, AXmm shr 3, 0, AReg shr 3);
+    ABuf.EmitByte($0F);
+    ABuf.EmitByte($6E);
+    EmitModRMReg(ABuf, AXmm, AReg);
+  end;
+
 begin
   case AIns.Op of
+    iroMoveVec:
+      begin
+        X64EmitLoadVec(ABuf, 0, AIns.A);
+        X64EmitStoreVec(ABuf, 0, AIns.Dest);
+      end;
+    iroV128Const:
+      begin
+        IrAuxReadV128(AAux, UInt32(AIns.Imm), VTmp);
+        X64EmitMovRegImm64(ABuf, X64_RAX, VTmp.U64[0]);
+        EmitMovQXmmFromReg(0, X64_RAX);
+        X64EmitMovRegImm64(ABuf, X64_RAX, VTmp.U64[1]);
+        EmitMovQXmmFromReg(1, X64_RAX);
+        X64EmitVecBinary(ABuf, $6C, 0, 1);   { PUNPCKLQDQ xmm0, xmm1 }
+        X64EmitStoreVec(ABuf, 0, AIns.Dest);
+      end;
     iroV128Not:
       begin
         X64EmitLoadVec(ABuf, 0, AIns.A);
@@ -4188,7 +4221,7 @@ begin
 
   else
     if X64NativeVecOp(AIns.Op) then
-      EmitNativeVec(ABuf, AIns)
+      EmitNativeVec(ABuf, AIns, AAux)
     else if X64LeafBinaryOp(AIns.Op) then
       EmitLeafBinary(ABuf, AIns)
     else if X64LeafUnaryOp(AIns.Op) then


### PR DESCRIPTION
## Summary

Profile-driven optimization wave (per the `optimize-runtime` skill). The serialized wasmbench baseline at `origin/main@8a01d6e` flagged compiled-tier SIMD as the outlier; a `sample(1)` profile attributed the samples to `InterpContextFor`, `FPC_MOVE`/`memmove`, and generated-code helper regions. The mechanism: every `iroMoveVec` (v128 `local.get`/`set`/`tee`) and every `iroV128Const` paid the full `JitVecDispatch` crossing in both compiling tiers — a native call, an activation lookup, a ~200-arm case dispatch, and a 16-byte record copy — even though the vector arithmetic ops were already natively emitted.

- **Arm64 (`0ad4959`)**: `iroMoveVec` emits one Q-register load/store pair; `iroV128Const` reads its bits from the IR aux block at compile time and bakes two movz/movk immediates into the destination slot pair.
- **x64 (`6a8c238`)**: mirror shape — MOVDQU load/store pair for the move; two movabs/MOVQ halves joined by PUNPCKLQDQ for the const.
- Everything else keeps the helper fallback. No new helpers, no ABI or artifact-format change, no scope-fence change, no interpreter change.

### Measured impact (serialized A/B, one warm-up discarded, 7 samples, BASE-CAND-CAND-BASE under `/tmp/wasmlight-perf-gate.lock`)

| Workload | Baseline | Candidate | Delta |
| --- | --- | --- | --- |
| simd jit, macOS/aarch64 | 126/126 ms | 69/69 ms | -45%, both orders |
| simd aot, macOS/aarch64 | 126/126 ms | 69/69 ms | -45%, both orders |
| simd jit, Linux/x86-64 (OrbStack VM) | 1432/1457 ms | 455/469 ms | -68%, both orders |
| simd aot, Linux/x86-64 (OrbStack VM) | 1117/1117 ms | 342/342 ms | -69%, both orders |
| loop/fib/memory/numeric/startup guards (both hosts) | flat | flat | within noise |

The x86-64 numbers are same-VM A/B evidence on virtualized amd64 over an Arm host, not native hardware claims.

## Testing

- New differential in `Wasm.Jit.Test`: a locals-dominated v128 module (const, set/get/tee, cross-local moves, slot overwrites) asserted bit-identical between compiled and interpreted execution.
- Full local gate on the exact head: `lwpt install --frozen`, `lwpt format --check`, `lwpt agents --check`, dev + release builds, `lwpt test` (44/44 suites), `npx markdownlint-cli2 "**/*.md"` — all pass on macOS/aarch64 and Linux/x86-64.
- The recursive 288-script corpus at pinned `de54fd27` is byte-identical across interpreter/JIT/AOT before and after: `pass=65851 fail=368 skip=904 staged=0 errors=0` on both architectures (compiled=8799 aarch64, 8800 x86-64).
- Benchmark numbers are measurement evidence only, not CI assertions.

## Linked issues

None — profile-driven wave opened directly from the recorded Wasmtime-gap scorecard.