### PR TITLE
perf(gc): accelerate allocation and struct/array field access

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,38 @@
 # Handoff
 
+Updated: 2026-08-22 (wave 3 candidate rejected; scalar memory + simd profiled)
+
+## Wave 3 — static cache for vector loops REJECTED and reverted
+
+- Lane `optimize/vec-static-cache` from `4d83d63`: admitted the natively
+  emitted vector op set (Arm64NativeVecOp/X64NativeVecOp — identical lists)
+  into StaticCacheOp and restricted cache-slot selection to wvkNum slots.
+  Built clean, results verified, but serialized simd A/B measured a
+  regression: cand medians 11.122/11.335 ms vs base 10.686/10.312 ms
+  (+4–10%, both orders). The extended-frame prologue plus per-exit
+  write-back cost more than caching the loop counter saved. Fully
+  reverted; nothing remains in the tree.
+- Profile facts recorded for the next lanes (both from `sample(1)` on long
+  AOT runs of scaled workload modules):
+  - Scalar memory-load/store: 100% of samples inside generated code, zero
+    helper crossings. The ~1.34x/1.51x residual vs Wasmtime is pure
+    codegen quality (loop overhead amortized over one access), not chokepoint
+    or helper cost — heavily mined territory (five prior waves, several
+    recorded rejections).
+  - SIMD workload: also 100% generated code now (PR #10 closed the helper
+    crossings). The disassembly shows the remaining cost is spill/reload
+    traffic through canonical frame slots and per-iteration rebuilding of
+    v128 constants (two movz/movk pairs + slot stores + Q load every
+    iteration). The bounded counter-caching lane above did not pay for it;
+    what remains is a Q-register static cache entry for vector locals
+    (v16-v31 are caller-saved and these functions are call-free) and/or
+    loop-invariant constant hoisting — both new machinery in both backends,
+    each its own future wave.
+- GC native inline allocation in the JIT/AOT backends remains the largest
+  open gap (gc ~104 ms vs Wasmtime ~28 ms): inline bump/free-list fast path
+  with the collect-slow-path call as the safepoint, per ADR-0011's
+  allocation-site stack-map obligation. Also its own wave.
+
 Updated: 2026-08-22 (wave 2: GC field access through pointers + WASI RemoveTree fix)
 
 ## Wave 2 — field/layout resolution and a test-harness hang

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,62 @@
 # Handoff
 
+Updated: 2026-08-21 (gc allocation fast-path wave)
+
+## GC allocation fast path
+
+- Branch `optimize/runtime-wave` from exact
+  `origin/main@659fd3711dd596176b7d86bdfc9d130e9b6e5015` (post-PR #10 tip).
+  Accepted commit `22053d6` (`perf(gc): consolidate the allocation fast path`)
+  on lane branch `optimize/gc-alloc-fastpath`, fast-forwarded into the
+  delivery branch. Delivery not requested; both branches are local and
+  unpushed.
+- Target selection. The previous wave's residual list named GC allocation as
+  the largest measured gap (~4.4x Wasmtime). Serialized baseline (release,
+  bench.py best profile, 7 samples) at the exact starting commit: gc
+  124.592 ms vs Wasmtime 28.282 ms (4.41x); guards loop 374.9, fib 33.0,
+  memory 21.6, memory-load 43.0, memory-store 43.2, simd 9.4, startup
+  2.93 ms.
+- Profile-driven mechanism. A `sample(1)` profile of a 20M-iteration gc AOT
+  run attributed ~270/741 samples to `TWasmGcHeap.AllocStruct` →
+  `Allocate`: duplicate size-class classification (Allocate computed
+  ClassOf/CellSize, then TakeCell recomputed them), layered helper calls,
+  generic FillChar→memset zeroing of every cell, plus amortized
+  Collect/Sweep; a further ~90 samples re-resolved type layouts through
+  `TWasmGcTypes.Layout`/`IsDefined` on every AllocStruct/StructField.
+- Accepted candidate (`22053d6`, Wasm.Runtime.Gc.pas only): TakeCell takes
+  the already-derived class index and cell size; per-cell zeroing uses an
+  inline u64 store loop up to 128 bytes (cells are 8-aligned, sizes are
+  multiples of 8) and keeps the RTL fill for large objects;
+  Allocate/ClassOf/TWasmGcTypes.Layout/IsDefined marked inline. No ABI,
+  artifact-format, safepoint, trap, or allocation-trigger change: Allocate
+  remains the only collection trigger and every byte of a cell is still
+  zero before the header goes down.
+- Serialized A/B under `/tmp/wasmlight-perf-gate.lock` (one warm-up
+  discarded, 7 samples, BASE-CAND-CAND-BASE): gc wasmlight median
+  127.498 → 118.107 ms forward and 117.819 vs 127.231 ms reverse (-7.4%
+  both orders, spreads disjoint: base 125.7–128.9, cand 115.7–119.9).
+  Guards forward then reverse: loop +2.68%/+0.40%, fib +1.27%/+0.17%,
+  simd +2.16%/+0.61%, memory-load −8.69%/+1.51%, memory-store
+  −10.74%/−3.70% — the forward memory deltas reversed sign and the wide
+  short-process spreads straddle zero, so guards are flat within noise and
+  the loop/fib/simd first-pass shifts were host-load drift, not code.
+- Combined integration head equals the lane head byte-for-byte (same
+  sha256 release binary), so the lane A/B is the combined measurement.
+- Correctness on the combined head (macOS/aarch64): frozen install, format
+  90/90, agents check, diff check, dev + release builds, Markdown lint, and
+  all 44 unit suites pass. The recursive 288-script corpus at `de54fd27` is
+  byte-identical across interpreter/JIT/AOT:
+  pass=65851 fail=368 skip=904 staged=0 errors=0 (compiled=8799).
+- Not yet done before any PR: the Linux/x86-64 leg (unit suites + corpus
+  identity). The change touches no generated-code emitter and no artifact
+  ABI, but prior runtime waves still proved x86-64 before delivery; CI on
+  the PR would cover it.
+- Rejected/not pursued this wave: caching resolved layout pointers per
+  object header (changes the object model for ~12% of samples — deferred);
+  native inline emission of struct.new/array.set in the JIT/AOT backends
+  (the shape that closed the SIMD gap, but a full backend lane — the
+  natural next wave if the remaining ~118 ms vs 28 ms gap must close).
+
 Updated: 2026-08-21 (native v128 move/const emission, both backends)
 
 ## v128 helper-crossing elimination

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,38 @@
 # Handoff
 
+Updated: 2026-08-22 (wave 2: GC field access through pointers + WASI RemoveTree fix)
+
+## Wave 2 — field/layout resolution and a test-harness hang
+
+- Lane `optimize/gc-field-access` from `1d8f188` (the wave-1 delivery head),
+  accepted commits `5bf5574` (`perf(gc): resolve struct and array fields
+  through pointers`) and `6d7eb49` (`fix(test): probe symlinks in the WASI
+  suite's RemoveTree`), fast-forwarded into `optimize/runtime-wave`. Local,
+  unpushed, delivery not requested.
+- Mechanism: StructField copied the resolved TWasmGcField record per access
+  and ArrayElement added a call layer plus a second copy; both re-resolved
+  layout every time. The candidate returns a PWasmGcField into the layout
+  table (StructFieldPtr) and folds null/kind/bounds/offset for scalar array
+  paths (ResolveElement); ReadField/WriteField/ExtendSigned take the field
+  by pointer.
+- Serialized gc A/B under the perf gate (7 samples, BASE-CAND-CAND-BASE):
+  116.743 → 104.604 ms forward and 104.531 vs 116.949 ms reverse (-10.5%
+  both orders, disjoint spreads). Guards in two rotated passes: loop
+  −1.0%/+0.1%, fib +0.5%/+1.2%, memory-load −2.2%/−4.0%,
+  memory-store −7.1%/−3.1%, simd +5.5%/−1.6%, startup +9.9%/−3.2% — the
+  simd/startup flips are short-process noise; no material regression.
+- Correctness on the combined head (`f0407e1` release binary): all 44 unit
+  suites pass; recursive corpus byte-identical in interpreter/JIT/AOT at
+  pass=65851 fail=368 skip=904 staged=0 errors=0, compiled=8799; format,
+  agents check, diff check, Markdown lint green.
+- Harness defect found by the wave: Wasm.Wasi.Test's RemoveTree relied on
+  faSymLink, which Darwin's FindFirst NEVER sets (it stats entries), so
+  `escape -> /etc` was recursed and system files were being unlinked; an
+  unlink there now wedges forever and hung any full-suite run that executed
+  the WASI suite (reproduced twice). Fixed with fpReadLink; suite drops
+  from hang to 2.7 s. Any environment where full suites stall in
+  Wasm.Wasi.Test should check for this class first.
+
 Updated: 2026-08-21 (gc allocation fast-path wave)
 
 ## GC allocation fast path

--- a/source/units/Wasm.Runtime.Gc.pas
+++ b/source/units/Wasm.Runtime.Gc.pas
@@ -246,10 +246,10 @@ type
       answer, because a layout is a pure function of the composite. }
     procedure Define(const AId: TWasmGcTypeId; const AComp: TWasmCompType);
 
-    function IsDefined(const AId: TWasmGcTypeId): Boolean;
+    function IsDefined(const AId: TWasmGcTypeId): Boolean; inline;
     { Raises EWasmError for an id with no layout — an internal invariant
       violation, since every engine type gets one at intern time. }
-    function Layout(const AId: TWasmGcTypeId): PWasmGcLayout;
+    function Layout(const AId: TWasmGcTypeId): PWasmGcLayout; inline;
     function Count: Integer;
   end;
 
@@ -429,13 +429,14 @@ type
     FThreshold: UInt64;
     FThresholdFloor: UInt64;
 
-    function ClassOf(const ASize: UInt32): Integer;
+    function ClassOf(const ASize: UInt32): Integer; inline;
     function NewBlock(const AClassIndex: Integer; const ACellSize: UInt32;
       const ACellCount: UInt32; const AIsLarge: Boolean): PWasmGcBlock;
     procedure FreeBlock(const ABlock: PWasmGcBlock);
-    function TakeCell(const ASize: UInt32): PByte;
+    function TakeCell(const AClassIndex: Integer; const ACellSize: UInt32;
+      const ASize: UInt32): PByte;
     function Allocate(const ASize: UInt32; const AKind: TWasmObjKind;
-      const ATypeId: TWasmGcTypeId): PByte;
+      const ATypeId: TWasmGcTypeId): PByte; inline;
     function AllocConvert(const AKind: TWasmObjKind;
       const AInner: TWasmRef): TWasmRef;
 
@@ -942,6 +943,43 @@ begin
   Result := (AOffset + (AAlign - 1)) and not (AAlign - 1);
 end;
 
+{ A cell's size is a multiple of WASM_GC_ALIGNMENT (8) and its address is
+  8-aligned, so the zero fill is whole u64 stores. The small sizes that
+  dominate allocation are written directly; only a large object pays the
+  RTL call, which is the same trade every hot-path primitive here makes
+  and which wasmspec's tracing semantics pin exactly: every byte of the
+  cell is zero before the header goes down. }
+procedure ZeroCell(const ACell: PByte; const ASize: UInt32); inline;
+var
+  Offset: UInt32;
+begin
+  if ASize > 128 then
+  begin
+    FillChar(ACell^, ASize, 0);
+    Exit;
+  end;
+  Offset := 0;
+  while Offset + 32 <= ASize do
+  begin
+    PWasmU64(ACell + Offset)^ := 0;
+    PWasmU64(ACell + Offset + 8)^ := 0;
+    PWasmU64(ACell + Offset + 16)^ := 0;
+    PWasmU64(ACell + Offset + 24)^ := 0;
+    Offset := Offset + 32;
+  end;
+  if Offset + 16 <= ASize then
+  begin
+    PWasmU64(ACell + Offset)^ := 0;
+    PWasmU64(ACell + Offset + 8)^ := 0;
+    Offset := Offset + 16;
+  end;
+  if Offset + 8 <= ASize then
+  begin
+    PWasmU64(ACell + Offset)^ := 0;
+    Offset := Offset + 8;
+  end;
+end;
+
 procedure TWasmGcTypes.Grow(const ACount: Integer);
 var
   Index: Integer;
@@ -1050,12 +1088,12 @@ begin
   Layout^.Defined := True;
 end;
 
-function TWasmGcTypes.IsDefined(const AId: TWasmGcTypeId): Boolean;
+function TWasmGcTypes.IsDefined(const AId: TWasmGcTypeId): Boolean; inline;
 begin
   Result := (AId < UInt32(Length(FLayouts))) and FLayouts[AId].Defined;
 end;
 
-function TWasmGcTypes.Layout(const AId: TWasmGcTypeId): PWasmGcLayout;
+function TWasmGcTypes.Layout(const AId: TWasmGcTypeId): PWasmGcLayout; inline;
 begin
   if not IsDefined(AId) then
     raise EWasmError.CreateFmt('internal: engine type %u has no layout',
@@ -1129,7 +1167,7 @@ begin
   FThreshold := AValue;
 end;
 
-function TWasmGcHeap.ClassOf(const ASize: UInt32): Integer;
+function TWasmGcHeap.ClassOf(const ASize: UInt32): Integer; inline;
 var
   Index: Integer;
 begin
@@ -1202,10 +1240,9 @@ begin
   Dispose(ABlock);
 end;
 
-function TWasmGcHeap.TakeCell(const ASize: UInt32): PByte;
+function TWasmGcHeap.TakeCell(const AClassIndex: Integer;
+  const ACellSize: UInt32; const ASize: UInt32): PByte;
 var
-  ClassIndex: Integer;
-  CellSize: UInt32;
   Block: PWasmGcBlock;
   Cell: UInt32;
 begin
@@ -1220,9 +1257,7 @@ begin
       '(a host release hook must not allocate)');
 {$ENDIF}
 
-  ClassIndex := ClassOf(ASize);
-
-  if ClassIndex < 0 then
+  if AClassIndex < 0 then
   begin
     { A large object owns its block. Freeing it outright at sweep is what
       keeps a heap that allocated one huge array from holding the memory
@@ -1239,45 +1274,43 @@ begin
     Exit(Block^.Base);
   end;
 
-  CellSize := WASM_GC_SIZE_CLASSES[ClassIndex];
-
-  Result := FFree[ClassIndex];
+  Result := FFree[AClassIndex];
   if Result <> nil then
   begin
     { The free list threads through the first two words of a free cell;
       the per-block bitmap, not the link, is what says a cell is free, so
       overwriting them on allocation loses nothing. }
-    FFree[ClassIndex] := PByte(NativeUInt(
+    FFree[AClassIndex] := PByte(NativeUInt(
       PWasmU64(Result + WASM_GC_FREE_LINK_OFFSET)^));
     Block := PWasmGcBlock(NativeUInt(
       PWasmU64(Result + WASM_GC_FREE_BLOCK_OFFSET)^));
-    Cell := UInt32(Result - Block^.Base) div CellSize;
+    Cell := UInt32(Result - Block^.Base) div ACellSize;
     SetCellAllocated(Block, Cell);
     Exit;
   end;
 
-  Block := FBump[ClassIndex];
+  Block := FBump[AClassIndex];
   if (Block = nil) or (Block^.Carved >= Block^.CellCount) then
   begin
-    Block := NewBlock(ClassIndex, CellSize,
-      UInt32(WASM_GC_BLOCK_BYTES) div CellSize, False);
+    Block := NewBlock(AClassIndex, ACellSize,
+      UInt32(WASM_GC_BLOCK_BYTES) div ACellSize, False);
     if Block = nil then
       Exit(nil);
     if FBlockCount >= Length(FBlocks) then
       SetLength(FBlocks, (FBlockCount + 1) * 2);
     FBlocks[FBlockCount] := Block;
     Inc(FBlockCount);
-    FBump[ClassIndex] := Block;
+    FBump[AClassIndex] := Block;
   end;
 
   Cell := Block^.Carved;
   Inc(Block^.Carved);
   SetCellAllocated(Block, Cell);
-  Result := Block^.Base + Cell * CellSize;
+  Result := Block^.Base + Cell * ACellSize;
 end;
 
 function TWasmGcHeap.Allocate(const ASize: UInt32;
-  const AKind: TWasmObjKind; const ATypeId: TWasmGcTypeId): PByte;
+  const AKind: TWasmObjKind; const ATypeId: TWasmGcTypeId): PByte; inline;
 var
   Size: UInt32;
   ClassIndex: Integer;
@@ -1309,7 +1342,7 @@ begin
   if (not FCollecting) and (FBytesLive + UInt64(CellSize) > FThreshold) then
     Collect;
 
-  Result := TakeCell(Size);
+  Result := TakeCell(ClassIndex, CellSize, Size);
   if (Result = nil) and (not FCollecting) then
   begin
     { The host allocator failed. Design §7.3 / M8: collect once and retry
@@ -1317,14 +1350,14 @@ begin
       otherwise (NewBlock used to trap on the spot). The retry reuses
       reclaimed cells first, then grows; only a still-nil result traps. }
     Collect;
-    Result := TakeCell(Size);
+    Result := TakeCell(ClassIndex, CellSize, Size);
   end;
   if Result = nil then
     TrapNow(wtkAllocationFailure);
 
   { A recycled cell holds whatever the last object left; zeroing before
     the header goes down is what stops the next collection tracing it. }
-  FillChar(Result^, CellSize, 0);
+  ZeroCell(Result, CellSize);
   { The mark bit is set to the current epoch's live value, so the next
     cycle's polarity flip unmarks this object cleanly along with every
     survivor (H8, design §7.1). }

--- a/source/units/Wasm.Runtime.Gc.pas
+++ b/source/units/Wasm.Runtime.Gc.pas
@@ -196,6 +196,7 @@ type
 
   TWasmGcFields = array of TWasmGcField;
   TWasmGcOffsets = array of UInt32;
+  PWasmGcField = ^TWasmGcField;
 
   PWasmGcLayout = ^TWasmGcLayout;
 
@@ -451,9 +452,15 @@ type
       const AValue: TWasmValue);
     procedure ReleaseObject(const ACell: PByte);
 
-    function LayoutOf(const ARef: TWasmRef): PWasmGcLayout;
+    function LayoutOf(const ARef: TWasmRef): PWasmGcLayout; inline;
+    { Pointer variant of StructField: the hot get/set paths index straight
+      into the layout table instead of copying the field record out. }
+    function StructFieldPtr(const ARef: TWasmRef;
+      const AField: UInt32): PWasmGcField; inline;
     function StructField(const ARef: TWasmRef;
       const AField: UInt32): TWasmGcField;
+    procedure ResolveElement(const ARef: TWasmRef;
+      const AIndex: UInt32; out ABase: PByte; out AField: TWasmGcField); inline;
     function ArrayElement(const ARef: TWasmRef;
       const AIndex: UInt32): TWasmGcField;
 
@@ -1525,22 +1532,22 @@ begin
 end;
 
 function ReadField(const ABase: PByte;
-  const AField: TWasmGcField): TWasmValue;
+  const AField: PWasmGcField): TWasmValue;
 begin
   { Bits is the canonical raw view and every read fills the whole slot,
     which is the same rule Wasm.Runtime.Values imposes on a register: a
     stale high half would be traced as a pointer. }
   Result.Bits := 0;
-  if AField.IsRef then
+  if AField^.IsRef then
   begin
-    Result.Bits := UInt64(PWasmRef(ABase + AField.Offset)^);
+    Result.Bits := UInt64(PWasmRef(ABase + AField^.Offset)^);
     Exit;
   end;
-  case AField.Width of
-    1: Result.Bits := UInt64(PWasmU8(ABase + AField.Offset)^);
-    2: Result.Bits := UInt64(PWasmU16(ABase + AField.Offset)^);
-    4: Result.Bits := UInt64(PWasmU32(ABase + AField.Offset)^);
-    8: Result.Bits := PWasmU64(ABase + AField.Offset)^;
+  case AField^.Width of
+    1: Result.Bits := UInt64(PWasmU8(ABase + AField^.Offset)^);
+    2: Result.Bits := UInt64(PWasmU16(ABase + AField^.Offset)^);
+    4: Result.Bits := UInt64(PWasmU32(ABase + AField^.Offset)^);
+    8: Result.Bits := PWasmU64(ABase + AField^.Offset)^;
     { Width 16 (v128) does not have an 8-byte scalar view: a v128 field is
       read only through ReadFieldV128, driven by the iroStructGetVec /
       iroArrayGetVec ops. The scalar path never asks for a v128 value —
@@ -1551,33 +1558,33 @@ end;
 
 { A 16-byte copy at the field's offset (simd-spec §7). A v128 is never
   packed, never a reference: no truncation, no sign-extension, no barrier. }
-procedure ReadFieldV128(const ABase: PByte; const AField: TWasmGcField;
+procedure ReadFieldV128(const ABase: PByte; const AField: PWasmGcField;
   const ADest: PWasmV128);
 begin
-  Move((ABase + AField.Offset)^, ADest^, 16);
+  Move((ABase + AField^.Offset)^, ADest^, 16);
 end;
 
-procedure WriteFieldV128(const ABase: PByte; const AField: TWasmGcField;
+procedure WriteFieldV128(const ABase: PByte; const AField: PWasmGcField;
   const ASrc: PWasmV128);
 begin
-  Move(ASrc^, (ABase + AField.Offset)^, 16);
+  Move(ASrc^, (ABase + AField^.Offset)^, 16);
 end;
 
-procedure WriteField(const ABase: PByte; const AField: TWasmGcField;
+procedure WriteField(const ABase: PByte; const AField: PWasmGcField;
   const AValue: TWasmValue);
 begin
-  if AField.IsRef then
+  if AField^.IsRef then
   begin
-    PWasmRef(ABase + AField.Offset)^ := TWasmRef(AValue.Bits);
+    PWasmRef(ABase + AField^.Offset)^ := TWasmRef(AValue.Bits);
     Exit;
   end;
   { A packed store TRUNCATES (`aux-packfield`), which the narrow store
     does by itself. }
-  case AField.Width of
-    1: PWasmU8(ABase + AField.Offset)^ := Byte(AValue.Bits);
-    2: PWasmU16(ABase + AField.Offset)^ := Word(AValue.Bits);
-    4: PWasmU32(ABase + AField.Offset)^ := UInt32(AValue.Bits);
-    8: PWasmU64(ABase + AField.Offset)^ := AValue.Bits;
+  case AField^.Width of
+    1: PWasmU8(ABase + AField^.Offset)^ := Byte(AValue.Bits);
+    2: PWasmU16(ABase + AField^.Offset)^ := Word(AValue.Bits);
+    4: PWasmU32(ABase + AField^.Offset)^ := UInt32(AValue.Bits);
+    8: PWasmU64(ABase + AField^.Offset)^ := AValue.Bits;
     { Width 16 (v128) is written only through WriteFieldV128 (the *Vec IR
       ops). The one scalar caller that names a v128 field is the
       new_default zeroing loop, and a v128's default is the zero the cell
@@ -1586,22 +1593,22 @@ begin
 end;
 
 function ExtendSigned(const AValue: TWasmValue;
-  const AField: TWasmGcField): Int32;
+  const AField: PWasmGcField): Int32;
 begin
   { `aux-unpackfield` sign-extends from the packed width. Written out
     rather than left to a cast so the i8 and i16 cases are visibly the
     same rule at two widths. }
-  if not AField.IsPacked then
+  if not AField^.IsPacked then
     raise EWasmError.Create(
       'internal: get_s on a field that is not packed');
-  if AField.PackedKind = wpkI8 then
+  if AField^.PackedKind = wpkI8 then
     Result := Int32(Int8(Byte(AValue.Bits)))
   else
     Result := Int32(Int16(Word(AValue.Bits)));
 end;
 
-function TWasmGcHeap.StructField(const ARef: TWasmRef;
-  const AField: UInt32): TWasmGcField;
+function TWasmGcHeap.StructFieldPtr(const ARef: TWasmRef;
+  const AField: UInt32): PWasmGcField;
 var
   Layout: PWasmGcLayout;
 begin
@@ -1617,7 +1624,13 @@ begin
     raise EWasmError.CreateFmt(
       'internal: struct field %u of %u', [AField,
       UInt32(Length(Layout^.Fields))]);
-  Result := Layout^.Fields[AField];
+  Result := @Layout^.Fields[AField];
+end;
+
+function TWasmGcHeap.StructField(const ARef: TWasmRef;
+  const AField: UInt32): TWasmGcField;
+begin
+  Result := StructFieldPtr(ARef, AField)^;
 end;
 
 function TWasmGcHeap.StructFieldCount(const ARef: TWasmRef): UInt32;
@@ -1630,10 +1643,10 @@ end;
 function TWasmGcHeap.StructGet(const ARef: TWasmRef;
   const AField: UInt32): TWasmValue;
 var
-  Field: TWasmGcField;
+  Field: PWasmGcField;
 begin
-  Field := StructField(ARef, AField);
-  if Field.IsPacked then
+  Field := StructFieldPtr(ARef, AField);
+  if Field^.IsPacked then
     raise EWasmError.Create(
       'internal: struct.get on a packed field needs get_s or get_u');
   Result := ReadField(PByte(RefToPointer(ARef)), Field);
@@ -1642,20 +1655,19 @@ end;
 function TWasmGcHeap.StructGetSigned(const ARef: TWasmRef;
   const AField: UInt32): Int32;
 var
-  Field: TWasmGcField;
+  Field: PWasmGcField;
 begin
-  Field := StructField(ARef, AField);
-  Result := ExtendSigned(ReadField(PByte(RefToPointer(ARef)), Field),
-    Field);
+  Field := StructFieldPtr(ARef, AField);
+  Result := ExtendSigned(ReadField(PByte(RefToPointer(ARef)), Field), Field);
 end;
 
 function TWasmGcHeap.StructGetUnsigned(const ARef: TWasmRef;
   const AField: UInt32): UInt32;
 var
-  Field: TWasmGcField;
+  Field: PWasmGcField;
 begin
-  Field := StructField(ARef, AField);
-  if not Field.IsPacked then
+  Field := StructFieldPtr(ARef, AField);
+  if not Field^.IsPacked then
     raise EWasmError.Create('internal: get_u on a field that is not packed');
   { Zero extension is what the narrow read already did. }
   Result := UInt32(ReadField(PByte(RefToPointer(ARef)), Field).Bits);
@@ -1664,24 +1676,24 @@ end;
 procedure TWasmGcHeap.StructSet(const ARef: TWasmRef; const AField: UInt32;
   const AValue: TWasmValue);
 var
-  Field: TWasmGcField;
+  Field: PWasmGcField;
 begin
-  Field := StructField(ARef, AField);
+  Field := StructFieldPtr(ARef, AField);
   WriteField(PByte(RefToPointer(ARef)), Field, AValue);
-  if Field.IsRef then
+  if Field^.IsRef then
     WriteBarrier(ARef, TWasmRef(AValue.Bits));
 end;
 
 procedure TWasmGcHeap.StructGetVec(const ARef: TWasmRef; const AField: UInt32;
   const ADest: PWasmV128);
 begin
-  ReadFieldV128(PByte(RefToPointer(ARef)), StructField(ARef, AField), ADest);
+  ReadFieldV128(PByte(RefToPointer(ARef)), StructFieldPtr(ARef, AField), ADest);
 end;
 
 procedure TWasmGcHeap.StructSetVec(const ARef: TWasmRef; const AField: UInt32;
   const ASrc: PWasmV128);
 begin
-  WriteFieldV128(PByte(RefToPointer(ARef)), StructField(ARef, AField), ASrc);
+  WriteFieldV128(PByte(RefToPointer(ARef)), StructFieldPtr(ARef, AField), ASrc);
 end;
 
 procedure TWasmGcHeap.StructSetDefaults(const ARef: TWasmRef);
@@ -1705,7 +1717,7 @@ begin
       because the validator should have rejected the module. }
     if not Layout^.Fields[Index].HasDefault then
       raise EWasmError.CreateFmt(MSG_GC_STRUCT_FIELD_NO_DEFAULT, [Index]);
-    WriteField(PByte(RefToPointer(ARef)), Layout^.Fields[Index], Value);
+    WriteField(PByte(RefToPointer(ARef)), @Layout^.Fields[Index], Value);
   end;
 end;
 
@@ -1736,60 +1748,93 @@ begin
   Result.Offset := Result.Offset + AIndex * Result.Width;
 end;
 
+{ The shared resolve behind the scalar array accessors: null check (O-5,
+  'null array reference'), kind check, bounds check, then the element's
+  field record with its per-index offset applied. Resolving inline instead
+  of calling ArrayElement keeps one call layer and one record copy off
+  each access. }
+procedure TWasmGcHeap.ResolveElement(const ARef: TWasmRef;
+  const AIndex: UInt32; out ABase: PByte; out AField: TWasmGcField); inline;
+var
+  Layout: PWasmGcLayout;
+begin
+  if RefIsNull(ARef) then
+    TrapNow(wtkNullArrayReference);
+  Layout := LayoutOf(ARef);
+  if Layout^.Kind <> wckArray then
+    raise EWasmError.Create('internal: not an array instance');
+  if AIndex >= ArrayLength(ARef) then
+    TrapNow(wtkArrayOutOfBounds);
+  ABase := PByte(RefToPointer(ARef));
+  AField := Layout^.Elem;
+  AField.Offset := AField.Offset + AIndex * AField.Width;
+end;
+
 function TWasmGcHeap.ArrayGet(const ARef: TWasmRef;
   const AIndex: UInt32): TWasmValue;
 var
+  Base: PByte;
   Field: TWasmGcField;
 begin
-  Field := ArrayElement(ARef, AIndex);
+  ResolveElement(ARef, AIndex, Base, Field);
   if Field.IsPacked then
     raise EWasmError.Create(
       'internal: array.get on a packed element needs get_s or get_u');
-  Result := ReadField(PByte(RefToPointer(ARef)), Field);
+  Result := ReadField(Base, @Field);
 end;
 
 function TWasmGcHeap.ArrayGetSigned(const ARef: TWasmRef;
   const AIndex: UInt32): Int32;
 var
+  Base: PByte;
   Field: TWasmGcField;
 begin
-  Field := ArrayElement(ARef, AIndex);
-  Result := ExtendSigned(ReadField(PByte(RefToPointer(ARef)), Field),
-    Field);
+  ResolveElement(ARef, AIndex, Base, Field);
+  Result := ExtendSigned(ReadField(Base, @Field), @Field);
 end;
 
 function TWasmGcHeap.ArrayGetUnsigned(const ARef: TWasmRef;
   const AIndex: UInt32): UInt32;
 var
+  Base: PByte;
   Field: TWasmGcField;
 begin
-  Field := ArrayElement(ARef, AIndex);
+  ResolveElement(ARef, AIndex, Base, Field);
   if not Field.IsPacked then
     raise EWasmError.Create('internal: get_u on an element that is not packed');
-  Result := UInt32(ReadField(PByte(RefToPointer(ARef)), Field).Bits);
+  Result := UInt32(ReadField(Base, @Field).Bits);
 end;
 
 procedure TWasmGcHeap.ArraySet(const ARef: TWasmRef; const AIndex: UInt32;
   const AValue: TWasmValue);
 var
+  Base: PByte;
   Field: TWasmGcField;
 begin
-  Field := ArrayElement(ARef, AIndex);
-  WriteField(PByte(RefToPointer(ARef)), Field, AValue);
+  ResolveElement(ARef, AIndex, Base, Field);
+  WriteField(Base, @Field, AValue);
   if Field.IsRef then
     WriteBarrier(ARef, TWasmRef(AValue.Bits));
 end;
 
 procedure TWasmGcHeap.ArrayGetVec(const ARef: TWasmRef; const AIndex: UInt32;
   const ADest: PWasmV128);
+var
+  Base: PByte;
+  Field: TWasmGcField;
 begin
-  ReadFieldV128(PByte(RefToPointer(ARef)), ArrayElement(ARef, AIndex), ADest);
+  ResolveElement(ARef, AIndex, Base, Field);
+  ReadFieldV128(Base, @Field, ADest);
 end;
 
 procedure TWasmGcHeap.ArraySetVec(const ARef: TWasmRef; const AIndex: UInt32;
   const ASrc: PWasmV128);
+var
+  Base: PByte;
+  Field: TWasmGcField;
 begin
-  WriteFieldV128(PByte(RefToPointer(ARef)), ArrayElement(ARef, AIndex), ASrc);
+  ResolveElement(ARef, AIndex, Base, Field);
+  WriteFieldV128(Base, @Field, ASrc);
 end;
 
 { The v128 twin of FillRange: layout, base and length read ONCE, the range
@@ -1819,7 +1864,7 @@ begin
   while Cursor < ACount do
   begin
     Field.Offset := ElemOffset + (AOffset + Cursor) * ElemWidth;
-    WriteFieldV128(Base, Field, ASrc);
+    WriteFieldV128(Base, @Field, ASrc);
     Inc(Cursor);
   end;
 end;
@@ -1858,7 +1903,7 @@ begin
   while Cursor < ACount do
   begin
     Field.Offset := ElemOffset + (AOffset + Cursor) * ElemWidth;
-    WriteField(Base, Field, AValue);
+    WriteField(Base, @Field, AValue);
     Inc(Cursor);
   end;
   { One barrier for the whole fill rather than one per element — the value
@@ -1964,8 +2009,8 @@ begin
       (ASrcIdx + Slot) * SrcLayout^.Elem.Width;
     DestField.Offset := DestLayout^.Elem.Offset +
       (ADestIdx + Slot) * DestLayout^.Elem.Width;
-    Value := ReadField(SrcBase, SrcField);
-    WriteField(DestBase, DestField, Value);
+    Value := ReadField(SrcBase, @SrcField);
+    WriteField(DestBase, @DestField, Value);
     { Barriered per reference element (empty in v1; the site is the point). }
     if DestField.IsRef then
       WriteBarrier(ADest, TWasmRef(Value.Bits));

--- a/source/units/Wasm.Wasi.Test.pas
+++ b/source/units/Wasm.Wasi.Test.pas
@@ -347,11 +347,13 @@ begin
           Full := IncludeTrailingPathDelimiter(APath) + Sr.Name;
           { A directory that is NOT a symlink is recursed; everything else
             (files, and symlinks even to dirs) is unlinked directly.
-            faSymLink carries a platform-portability warning we accept — it is
-            the correct guard against following a symlinked directory. }
+            faSymLink cannot be trusted here: Darwin's FindFirst stats the
+            entry, so a symlinked directory arrives as a plain directory and
+            the attr guard would follow `escape -> /etc` and try to unlink
+            system files. fpReadLink asks the question lstat does. }
           {$PUSH}{$WARN SYMBOL_PLATFORM OFF}
           if ((Sr.Attr and faDirectory) <> 0) and
-            ((Sr.Attr and faSymLink) = 0) then
+            (fpReadLink(RawByteString(Full)) = '') then
           {$POP}
             RemoveTree(Full)
           else

--- a/source/units/Wasm.Wasi.Test.pas
+++ b/source/units/Wasm.Wasi.Test.pas
@@ -347,13 +347,19 @@ begin
           Full := IncludeTrailingPathDelimiter(APath) + Sr.Name;
           { A directory that is NOT a symlink is recursed; everything else
             (files, and symlinks even to dirs) is unlinked directly.
-            faSymLink cannot be trusted here: Darwin's FindFirst stats the
+            On UNIX faSymLink cannot be trusted: Darwin's FindFirst stats the
             entry, so a symlinked directory arrives as a plain directory and
             the attr guard would follow `escape -> /etc` and try to unlink
-            system files. fpReadLink asks the question lstat does. }
+            system files. fpReadLink asks the question lstat does. Windows
+            keeps the attr check — its FindFirst reports symlinks directly. }
           {$PUSH}{$WARN SYMBOL_PLATFORM OFF}
+          {$IFDEF UNIX}
           if ((Sr.Attr and faDirectory) <> 0) and
             (fpReadLink(RawByteString(Full)) = '') then
+          {$ELSE}
+          if ((Sr.Attr and faDirectory) <> 0) and
+            ((Sr.Attr and faSymLink) = 0) then
+          {$ENDIF}
           {$POP}
             RemoveTree(Full)
           else


### PR DESCRIPTION
## Summary

Two measured optimization waves from the `optimize-runtime` protocol, targeting the GC-allocation gap named in the handoff's residual list (wasmlight ~4.4x Wasmtime on the bounded-live-set workload):

- **`perf(gc): consolidate the allocation fast path`** — `TakeCell` recomputed the size class and cell size that `Allocate` had already derived; pass them through instead. Replace per-cell `FillChar` with an inline u64 zeroing loop for the small size classes that dominate allocation. No change to the collection trigger, safepoints, or tracing: every byte of a cell is still zero before the header goes down.
- **`perf(gc): resolve struct and array fields through pointers`** — `StructField` copied the resolved field record per access and `ArrayElement` added a call layer plus a second copy; both re-resolved layout every time. Hot paths now index the layout table directly (`StructFieldPtr`, `ResolveElement`).
- **`fix(test): probe symlinks in the WASI suite's RemoveTree`** — Darwin's `FindFirst` stats entries and never sets `faSymLink`, so the suite followed its `escape -> /etc` fixture symlink into the real `/etc` and now wedges forever on one unlink, hanging any full-suite run that executes it (reproduced twice). `fpReadLink` asks the lstat question instead; the suite drops from hang to ~2.7 s.
- Three `.agent/HANDOFF.md` commits record each wave's profile attribution, serialized A/B evidence, rejected experiments, and next lanes.

Measured medians (Apple M5 Max, release builds, `tools/runtime-comparison/bench.py` best profile, 1 warm-up discarded + 7 samples, rotated orders under `/tmp/wasmlight-perf-gate.lock`; benchmark numbers are informational, never CI assertions):

| Workload | main | this branch |
| --- | ---: | ---: |
| gc (2M allocs) | 127.5 / 127.2 ms | 118.1 / 117.8 ms (**−7.4%**), then 116.7 → 104.6 ms (**−10.5%**) |

Guards (loop, fib, memory-load/store, simd, startup) flat within noise across order-reversed confirmation passes.

## Testing

- Focused: all 44 co-located suites pass at the exact head (`lwpt test`, 68 s).
- Tier identity: recursive 288-script corpus byte-identical in interpreter/JIT/AOT — `pass=65851 fail=368 skip=904 staged=0 errors=0`, JIT/AOT `compiled=8799` on macOS/aarch64.
- Universal gate observed green at head `3bf7d68`: `lwpt install --frozen`, `lwpt format --check` (90 files), `lwpt agents --check`, dev + release builds, `git diff --check`, markdownlint.
- The Linux/x86-64 corpus legs are left to this PR's CI; no backend emitter or artifact ABI changed.

## Linked issues

No tracked issue; work produced by the optimize-runtime skill waves. Follow-up lanes (Q-register vector caching, native inline GC allocation) are recorded in `.agent/HANDOFF.md`.
