### PR TITLE
refactor(core): classify internal invariant defects as EWasmInternal; set analysis gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,10 @@ canonical vocabulary before planning anything.
   guest-requested exit raised by WASI `proc_exit` — is a further sibling
   under `EWasmError`, declared in `Wasm.Engine`: it is neither a fault nor
   a `throw`, so never fold it into `EWasmTrap` or `EWasmException`; `run`
-  maps it to the process exit code.
+  maps it to the process exit code. Internal invariant defects — the
+  `"internal: ..."` sites on paths the validator's proof makes unreachable —
+  raise `EWasmInternal`, a leaf under `EWasmError`: never on a
+  module-facing path, and never in place of one of the classes above.
 - **A store belongs to one thread**
   ([ADR-0008](docs/adr/0008-a-store-is-confined-to-one-thread.md)). Do not
   add synchronisation to runtime structures "just in case" — that cost is

--- a/lwpt.toml
+++ b/lwpt.toml
@@ -44,3 +44,18 @@ stamp-version = { command = "instantfpc",
 # project-owned Pascal that is not a unit, so it is added explicitly.
 [format]
 include = ["scripts/*.pas"]
+
+# Analysis gates. Every limit sits just above the measured baseline
+# (lwpt health / lwpt duplication, 2026-08 audit): file cyclomatic 1147,
+# file cognitive 988, routine cyclomatic 497, routine cognitive 182,
+# duplication 9.3%. These are regression ratchets — CI fails when a
+# change pushes a metric past its ceiling; lowering a ceiling IS the
+# follow-up refactor, never a drive-by edit.
+[health]
+max-file-cyclomatic = 1200
+max-file-cognitive = 1050
+max-routine-cyclomatic = 520
+max-routine-cognitive = 200
+
+[duplication]
+maximum-percent = 10

--- a/source/units/Wasm.Aot.Artifact.pas
+++ b/source/units/Wasm.Aot.Artifact.pas
@@ -519,7 +519,7 @@ begin
   { The header is exactly WAOT_HEADER_SIZE by construction; assert the invariant
     the reader relies on. }
   if Out_.Len <> WAOT_HEADER_SIZE then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: .waot header is %d bytes, expected %d',
       [Out_.Len, WAOT_HEADER_SIZE]);
   WBytes(Out_, Body.Buf);

--- a/source/units/Wasm.Core.Test.pas
+++ b/source/units/Wasm.Core.Test.pas
@@ -41,6 +41,7 @@ type
     procedure TestExternKindOrdinals;
     procedure TestExternalTypeConstructors;
     procedure TestCompTypeConstructors;
+    procedure TestInternalErrorClassHierarchy;
   end;
 
 function TCoreTests.DescribeCode(const ACode: Int64): string;
@@ -330,6 +331,30 @@ begin
   Expect<string>(Comp.Arr.Elem.Describe).ToBe('i16');
 end;
 
+procedure TCoreTests.TestInternalErrorClassHierarchy;
+var
+  Raised: Boolean;
+begin
+  { EWasmInternal is the runtime-invariant leaf: under EWasmError so a
+    host's broadest handler still catches it, but a SIBLING of the five
+    module-facing classes, never a subclass of one of them — an internal
+    defect must never surface as a decode/validation/link/trap claim. }
+  Expect<Boolean>(EWasmInternal.InheritsFrom(EWasmError)).ToBe(True);
+  Expect<Boolean>(EWasmInternal.InheritsFrom(EWasmDecodeError)).ToBe(False);
+  Expect<Boolean>(EWasmInternal.InheritsFrom(EWasmValidationError)).ToBe(False);
+  Expect<Boolean>(EWasmInternal.InheritsFrom(EWasmLinkError)).ToBe(False);
+  Expect<Boolean>(EWasmInternal.InheritsFrom(EWasmTrap)).ToBe(False);
+  Expect<Boolean>(EWasmInternal.InheritsFrom(EWasmException)).ToBe(False);
+  Raised := False;
+  try
+    raise EWasmInternal.Create('internal: probe');
+  except
+    on E: EWasmError do
+      Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
 procedure TCoreTests.SetupTests;
 begin
   Test('number type codes', TestNumTypeCodes);
@@ -353,6 +378,7 @@ begin
   Test('extern kind ordinals', TestExternKindOrdinals);
   Test('external type constructors', TestExternalTypeConstructors);
   Test('composite type constructors', TestCompTypeConstructors);
+  Test('internal error class hierarchy', TestInternalErrorClassHierarchy);
 end;
 
 begin

--- a/source/units/Wasm.Core.pas
+++ b/source/units/Wasm.Core.pas
@@ -312,6 +312,15 @@ type
   EWasmLinkError = class(EWasmError);
   EWasmTrap = class(EWasmError);
 
+  { An internal invariant failure: a "internal: ..." defect on a code path
+    the validator's type check proves unreachable for a validated module.
+    NOT part of the host-facing vocabulary above — those five classes mean
+    something about the MODULE or the invocation, this one means the
+    runtime contradicted its own proof. It stays under EWasmError so a
+    host's broadest handler still catches it, but it is never raised where
+    a module-facing class applies, and no module-facing path may raise it. }
+  EWasmInternal = class(EWasmError);
+
   { An uncaught WebAssembly exception (`throw` / `throw_ref`) that reached the
     invocation boundary with no `try_table` clause catching it. A SIBLING of
     EWasmTrap, not a subclass (see the hierarchy note above): the unwind that

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -390,7 +390,7 @@ var
   I: UInt32;
 begin
   if ACount > WASM_TIER_TAIL_CAP then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: cross-tier tail-call arity exceeds the marshal cap');
   I := 0;
   while I < ACount do
@@ -699,7 +699,7 @@ begin
        stack local, not managed state a TrapNow could skip. }
   ArgN := IrAuxBlockCount(ATop^.Fn^.AuxU32, AArgAux);
   if ArgN > WASM_INTERP_MAX_MARSHAL then
-    raise EWasmError.Create('internal: tail-call arity exceeds the marshal cap');
+    raise EWasmInternal.Create('internal: tail-call arity exceeds the marshal cap');
   TopRegs := Frame(ACtx^.Values, ATop^.Base);
   I := 0;
   while I < ArgN do
@@ -748,7 +748,7 @@ begin
   ArgN := IrAuxBlockCount(ACaller^.Fn^.AuxU32, AArgAux);
   ResN := IrAuxBlockCount(ACaller^.Fn^.AuxU32, ADstAux);
   if (ArgN > WASM_INTERP_MAX_MARSHAL) or (ResN > WASM_INTERP_MAX_MARSHAL) then
-    raise EWasmError.Create('internal: host-call arity exceeds the marshal cap');
+    raise EWasmInternal.Create('internal: host-call arity exceeds the marshal cap');
 
   CallerRegs := Frame(ACtx^.Values, ACaller^.Base);
   I := 0;
@@ -786,7 +786,7 @@ begin
   ArgN := IrAuxBlockCount(ATop^.Fn^.AuxU32, AArgAux);
   ResN := ATop^.Fn^.ResultCount;   { equals the host func's result arity }
   if (ArgN > WASM_INTERP_MAX_MARSHAL) or (ResN > WASM_INTERP_MAX_MARSHAL) then
-    raise EWasmError.Create('internal: host-call arity exceeds the marshal cap');
+    raise EWasmInternal.Create('internal: host-call arity exceeds the marshal cap');
 
   TopRegs := Frame(ACtx^.Values, ATop^.Base);
   I := 0;
@@ -882,7 +882,7 @@ begin
   ArgN := IrAuxBlockCount(ACaller^.Fn^.AuxU32, AArgAux);
   ResN := IrAuxBlockCount(ACaller^.Fn^.AuxU32, ADstAux);
   if (ArgN > WASM_INTERP_MAX_MARSHAL) or (ResN > WASM_INTERP_MAX_MARSHAL) then
-    raise EWasmError.Create('internal: compiled-call arity exceeds the marshal cap');
+    raise EWasmInternal.Create('internal: compiled-call arity exceeds the marshal cap');
 
   CallerRegs := Frame(ACtx^.Values, ACaller^.Base);
   I := 0;
@@ -941,7 +941,7 @@ begin
   ArgN := IrAuxBlockCount(ATop^.Fn^.AuxU32, AArgAux);
   ResN := ATop^.Fn^.ResultCount;   { equals the tail callee's result arity }
   if (ArgN > WASM_INTERP_MAX_MARSHAL) or (ResN > WASM_INTERP_MAX_MARSHAL) then
-    raise EWasmError.Create('internal: compiled-call arity exceeds the marshal cap');
+    raise EWasmInternal.Create('internal: compiled-call arity exceeds the marshal cap');
 
   TopRegs := Frame(ACtx^.Values, ATop^.Base);
   I := 0;
@@ -1054,7 +1054,7 @@ var
 begin
   ArgN := IrAuxBlockCount(ATop^.Fn^.AuxU32, AArgAux);
   if ArgN > WASM_TIER_TAIL_CAP then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: cross-tier tail-call arity exceeds the marshal cap');
   TopRegs := Frame(ACtx^.Values, ATop^.Base);
   I := 0;
@@ -1705,7 +1705,7 @@ end;
   managed locals, so every string lives in a leaf like this one. }
 procedure UnhandledOp(const AOp: TWasmIrOp);
 begin
-  raise EWasmError.Create('internal: unhandled IR op ' + IrOpMnemonic(AOp));
+  raise EWasmInternal.Create('internal: unhandled IR op ' + IrOpMnemonic(AOp));
 end;
 
 { --- exception delivery + the explicit unwind (eh-spec §2.3) -------------

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -1661,7 +1661,7 @@ begin
       if not Emitted then
         { The predicate guaranteed every op is emittable; reaching here is an
           internal inconsistency, not a fall-back path. }
-        raise EWasmError.CreateFmt(
+        raise EWasmInternal.CreateFmt(
           'internal: JIT predicate passed but op %d has no template',
           [Ord(AFn^.Code[I].Op)]);
     end;

--- a/source/units/Wasm.Runtime.Gc.pas
+++ b/source/units/Wasm.Runtime.Gc.pas
@@ -809,7 +809,7 @@ end;
 function HeaderOf(const ARef: TWasmRef): PWasmU64; inline;
 begin
   if not RefIsObject(ARef) then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: a null or i31 reference has no heap object header');
   Result := PWasmU64(RefToPointer(ARef));
 end;
@@ -855,7 +855,7 @@ var
 begin
   Header := HeaderOf(ARef);
   if KindOfHeader(Header^) <> wokFuncRef then
-    raise EWasmError.Create('internal: not a function reference');
+    raise EWasmInternal.Create('internal: not a function reference');
   Result := PWasmU32(PByte(Header) + WASM_FUNCREF_ADDR_OFFSET)^;
 end;
 
@@ -865,7 +865,7 @@ var
 begin
   Header := HeaderOf(ARef);
   if KindOfHeader(Header^) <> wokHostBox then
-    raise EWasmError.Create('internal: not a host box');
+    raise EWasmInternal.Create('internal: not a host box');
   Result := PNativeUInt(PByte(Header) + WASM_HOSTBOX_PAYLOAD_OFFSET)^;
 end;
 
@@ -877,7 +877,7 @@ begin
   Header := HeaderOf(ARef);
   Kind := KindOfHeader(Header^);
   if (Kind <> wokExternalized) and (Kind <> wokInternalized) then
-    raise EWasmError.Create('internal: not a converted reference');
+    raise EWasmInternal.Create('internal: not a converted reference');
   Result := PWasmRef(PByte(Header) + WASM_CONVERT_INNER_OFFSET)^;
 end;
 
@@ -1019,7 +1019,7 @@ begin
     collect; growing FLayouts here mid-collection would dangle it. Define
     runs at intern time, never during a cycle — assert it (B21/L21). }
   if GWasmGcCollecting then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: a GC type layout was defined during collection');
 {$ENDIF}
 
@@ -1103,7 +1103,7 @@ end;
 function TWasmGcTypes.Layout(const AId: TWasmGcTypeId): PWasmGcLayout; inline;
 begin
   if not IsDefined(AId) then
-    raise EWasmError.CreateFmt('internal: engine type %u has no layout',
+    raise EWasmInternal.CreateFmt('internal: engine type %u has no layout',
       [AId]);
   Result := @FLayouts[AId];
 end;
@@ -1259,7 +1259,7 @@ begin
     skips its collect while FCollecting, so a re-entrant alloc reaches
     TakeCell directly — make that loud rather than silent. }
   if FCollecting then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: allocation during collection ' +
       '(a host release hook must not allocate)');
 {$ENDIF}
@@ -1327,7 +1327,7 @@ begin
   { Collection never allocates; a re-entrant call here is a host release
     hook breaking its no-alloc contract (B10). }
   if FCollecting then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: allocation during collection ' +
       '(a host release hook must not allocate)');
 {$ENDIF}
@@ -1383,7 +1383,7 @@ var
 begin
   Layout := FTypes.Layout(ATypeId);
   if Layout^.Kind <> wckStruct then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: engine type %u is not a struct type', [ATypeId]);
   Result := MakeObjectRef(Allocate(Layout^.Size, wokStruct, ATypeId));
 end;
@@ -1397,7 +1397,7 @@ var
 begin
   Layout := FTypes.Layout(ATypeId);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: engine type %u is not an array type', [ATypeId]);
 
   { Computed in u64 and compared before narrowing: a length near 2^32 with
@@ -1463,7 +1463,7 @@ begin
     failure H8 has to unwind. Catch it here, before the object exists. }
   Layout := FTypes.Layout(ATypeId);
   if Layout^.Kind <> wckFunc then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: engine type %u is not a tag (func) type', [ATypeId]);
 
   Bytes := UInt64(WASM_EXN_ARGS_OFFSET) +
@@ -1599,7 +1599,7 @@ begin
     rather than left to a cast so the i8 and i16 cases are visibly the
     same rule at two widths. }
   if not AField^.IsPacked then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: get_s on a field that is not packed');
   if AField^.PackedKind = wpkI8 then
     Result := Int32(Int8(Byte(AValue.Bits)))
@@ -1619,9 +1619,9 @@ begin
     TrapNow(wtkNullStructReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckStruct then
-    raise EWasmError.Create('internal: not a struct instance');
+    raise EWasmInternal.Create('internal: not a struct instance');
   if AField >= UInt32(Length(Layout^.Fields)) then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: struct field %u of %u', [AField,
       UInt32(Length(Layout^.Fields))]);
   Result := @Layout^.Fields[AField];
@@ -1647,7 +1647,7 @@ var
 begin
   Field := StructFieldPtr(ARef, AField);
   if Field^.IsPacked then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: struct.get on a packed field needs get_s or get_u');
   Result := ReadField(PByte(RefToPointer(ARef)), Field);
 end;
@@ -1668,7 +1668,7 @@ var
 begin
   Field := StructFieldPtr(ARef, AField);
   if not Field^.IsPacked then
-    raise EWasmError.Create('internal: get_u on a field that is not packed');
+    raise EWasmInternal.Create('internal: get_u on a field that is not packed');
   { Zero extension is what the narrow read already did. }
   Result := UInt32(ReadField(PByte(RefToPointer(ARef)), Field).Bits);
 end;
@@ -1706,7 +1706,7 @@ begin
     TrapNow(wtkNullStructReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckStruct then
-    raise EWasmError.Create('internal: not a struct instance');
+    raise EWasmInternal.Create('internal: not a struct instance');
   Value.Bits := 0;
   for Index := 0 to High(Layout^.Fields) do
   begin
@@ -1741,7 +1741,7 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create('internal: not an array instance');
+    raise EWasmInternal.Create('internal: not an array instance');
   if AIndex >= ArrayLength(ARef) then
     TrapNow(wtkArrayOutOfBounds);
   Result := Layout^.Elem;
@@ -1762,7 +1762,7 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create('internal: not an array instance');
+    raise EWasmInternal.Create('internal: not an array instance');
   if AIndex >= ArrayLength(ARef) then
     TrapNow(wtkArrayOutOfBounds);
   ABase := PByte(RefToPointer(ARef));
@@ -1778,7 +1778,7 @@ var
 begin
   ResolveElement(ARef, AIndex, Base, Field);
   if Field.IsPacked then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: array.get on a packed element needs get_s or get_u');
   Result := ReadField(Base, @Field);
 end;
@@ -1801,7 +1801,7 @@ var
 begin
   ResolveElement(ARef, AIndex, Base, Field);
   if not Field.IsPacked then
-    raise EWasmError.Create('internal: get_u on an element that is not packed');
+    raise EWasmInternal.Create('internal: get_u on an element that is not packed');
   Result := UInt32(ReadField(Base, @Field).Bits);
 end;
 
@@ -1852,7 +1852,7 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create('internal: not an array instance');
+    raise EWasmInternal.Create('internal: not an array instance');
   Base := PByte(RefToPointer(ARef));
   Len := UInt32(PWasmU64(Base + WASM_ARRAY_LENGTH_OFFSET)^);
   if (AOffset > Len) or (ACount > Len - AOffset) then
@@ -1888,7 +1888,7 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create('internal: not an array instance');
+    raise EWasmInternal.Create('internal: not an array instance');
   Base := PByte(RefToPointer(ARef));
   Len := UInt32(PWasmU64(Base + WASM_ARRAY_LENGTH_OFFSET)^);
   { Overflow-safe range test (array.fill traps out of bounds): guard the
@@ -1934,7 +1934,7 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ARef);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create('internal: not an array instance');
+    raise EWasmInternal.Create('internal: not an array instance');
   { A zeroed object already holds aux-default's value for every
     defaultable storage type; what this adds is the CHECK that one exists,
     which is the invariant array.new_default relies on. }
@@ -1969,11 +1969,11 @@ begin
     TrapNow(wtkNullArrayReference);
   DestLayout := LayoutOf(ADest);
   if DestLayout^.Kind <> wckArray then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: array.copy destination is not an array');
   SrcLayout := LayoutOf(ASrc);
   if SrcLayout^.Kind <> wckArray then
-    raise EWasmError.Create('internal: array.copy source is not an array');
+    raise EWasmInternal.Create('internal: array.copy source is not an array');
 
   DestBase := PByte(RefToPointer(ADest));
   SrcBase := PByte(RefToPointer(ASrc));
@@ -2038,12 +2038,12 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ADest);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: array.init_data target is not an array');
   { array.init_data's element type is numeric or packed, never a reference
     (the validator guarantees it), so no write barrier is owed. }
   if Layout^.Elem.IsRef then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: array.init_data on a reference-element array');
 
   Base := PByte(RefToPointer(ADest));
@@ -2099,10 +2099,10 @@ begin
     TrapNow(wtkNullArrayReference);
   Layout := LayoutOf(ADest);
   if Layout^.Kind <> wckArray then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: array.init_elem target is not an array');
   if not Layout^.Elem.IsRef then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: array.init_elem on a non-reference-element array');
 
   Base := PByte(RefToPointer(ADest));
@@ -2148,7 +2148,7 @@ function TWasmGcHeap.ExnArg(const ARef: TWasmRef;
   const AIndex: UInt32): TWasmValue;
 begin
   if AIndex >= ExnArgCount(ARef) then
-    raise EWasmError.CreateFmt('internal: exception argument %u of %u',
+    raise EWasmInternal.CreateFmt('internal: exception argument %u of %u',
       [AIndex, ExnArgCount(ARef)]);
   Result := PWasmValue(PByte(RefToPointer(ARef)) + WASM_EXN_ARGS_OFFSET +
     AIndex * SizeOf(TWasmValue))^;
@@ -2162,7 +2162,7 @@ var
   IsRefArg: Boolean;
 begin
   if AIndex >= ExnArgCount(ARef) then
-    raise EWasmError.CreateFmt('internal: exception argument %u of %u',
+    raise EWasmInternal.CreateFmt('internal: exception argument %u of %u',
       [AIndex, ExnArgCount(ARef)]);
   PWasmValue(PByte(RefToPointer(ARef)) + WASM_EXN_ARGS_OFFSET +
     AIndex * SizeOf(TWasmValue))^ := AValue;
@@ -2210,7 +2210,7 @@ end;
 function TWasmGcHeap.RootGet(const AHandle: TWasmRootHandle): TWasmRef;
 begin
   if AHandle >= UInt32(FRootCount) then
-    raise EWasmError.CreateFmt('internal: no root handle %u', [AHandle]);
+    raise EWasmInternal.CreateFmt('internal: no root handle %u', [AHandle]);
   { No read barrier and no indirection: the collector never moves an
     object, which is the whole reason it is mark-sweep. }
   Result := FRoots[AHandle];
@@ -2220,14 +2220,14 @@ procedure TWasmGcHeap.RootSet(const AHandle: TWasmRootHandle;
   const ARef: TWasmRef);
 begin
   if AHandle >= UInt32(FRootCount) then
-    raise EWasmError.CreateFmt('internal: no root handle %u', [AHandle]);
+    raise EWasmInternal.CreateFmt('internal: no root handle %u', [AHandle]);
   FRoots[AHandle] := ARef;
 end;
 
 procedure TWasmGcHeap.RootRelease(const AHandle: TWasmRootHandle);
 begin
   if AHandle >= UInt32(FRootCount) then
-    raise EWasmError.CreateFmt('internal: no root handle %u', [AHandle]);
+    raise EWasmInternal.CreateFmt('internal: no root handle %u', [AHandle]);
   FRoots[AHandle] := WASM_REF_NULL;
   if AHandle = UInt32(FRootCount - 1) then
   begin
@@ -2253,7 +2253,7 @@ var
   Write: Integer;
 begin
   if AMark > UInt32(FRootCount) then
-    raise EWasmError.Create('internal: root scope mark is above the stack');
+    raise EWasmInternal.Create('internal: root scope mark is above the stack');
   FRootCount := Integer(AMark);
   { Free-list entries above the mark name slots that no longer exist;
     dropping them is what keeps the stack discipline and the free list
@@ -2282,7 +2282,7 @@ end;
 procedure TWasmGcHeap.PopFrame;
 begin
   if FFrames = nil then
-    raise EWasmError.Create('internal: popping an empty frame chain');
+    raise EWasmInternal.Create('internal: popping an empty frame chain');
   FFrames := FFrames^.Prev;
 end;
 

--- a/source/units/Wasm.Runtime.Instantiate.pas
+++ b/source/units/Wasm.Runtime.Instantiate.pas
@@ -218,7 +218,7 @@ end;
 procedure CheckReg(const AReg, ACount: UInt32; const AWhat: string);
 begin
   if AReg >= ACount then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: constant expression names register %u of %u (%s)',
       [AReg, ACount, AWhat]);
 end;
@@ -231,7 +231,7 @@ function EngineIdOf(const AInstance: TWasmModuleInstance;
   const ATypeIndex: UInt32): TWasmEngineTypeId;
 begin
   if ATypeIndex >= UInt32(Length(AInstance.EngineTypeIds)) then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: constant expression names type %u of %u',
       [ATypeIndex, UInt32(Length(AInstance.EngineTypeIds))]);
   Result := AInstance.EngineTypeIds[ATypeIndex];
@@ -267,7 +267,7 @@ var
 
 begin
   if Length(AExpr.Code) = 0 then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: evaluating an absent constant expression');
 
   Count := AExpr.RegisterCount;
@@ -376,7 +376,7 @@ begin
           CheckReg(Instr.Dest, Count, 'ref.func');
           FuncIndex := UInt32(Instr.Imm);
           if FuncIndex >= UInt32(Length(AInstance.FuncAddrs)) then
-            raise EWasmError.CreateFmt(
+            raise EWasmInternal.CreateFmt(
               'internal: ref.func names function %u of %u',
               [FuncIndex, UInt32(Length(AInstance.FuncAddrs))]);
           Addr := AInstance.FuncAddrs[FuncIndex];
@@ -399,7 +399,7 @@ begin
           CheckReg(Instr.Dest, Count, 'global.get');
           GlobalIndex := UInt32(Instr.Imm);
           if GlobalIndex >= UInt32(Length(AInstance.GlobalAddrs)) then
-            raise EWasmError.CreateFmt(
+            raise EWasmInternal.CreateFmt(
               'internal: global.get names global %u of %u',
               [GlobalIndex, UInt32(Length(AInstance.GlobalAddrs))]);
           Addr := AInstance.GlobalAddrs[GlobalIndex];
@@ -712,7 +712,7 @@ begin
       AIr.TableInits[ADefinedIndex]).Ref);
 
   if not AIr.Tables[ModuleIndex].RefType.Nullable then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: table %u has a non-nullable element type and no '
       + 'initialiser', [ModuleIndex]);
   Result := WASM_REF_NULL;
@@ -1004,7 +1004,7 @@ begin
     if (Span.Size > 0) and
       ((ABytes = nil) or (Span.Offset > ABytesLength) or
        (Span.Size > ABytesLength - Span.Offset)) then
-      raise EWasmError.CreateFmt(
+      raise EWasmInternal.CreateFmt(
         'internal: data segment %d spans [%u, %u) outside a %u-byte '
         + 'buffer', [Index, UInt64(Span.Offset),
         UInt64(Span.Offset) + UInt64(Span.Size), UInt64(ABytesLength)]);

--- a/source/units/Wasm.Runtime.Store.pas
+++ b/source/units/Wasm.Runtime.Store.pas
@@ -989,7 +989,7 @@ begin
   if AHeap.IsAbstract then
     Exit;
   if AHeap.TypeIndex >= UInt32(Length(AMap)) then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: type index %u has no engine id', [AHeap.TypeIndex]);
   Result.TypeIndex := AMap[AHeap.TypeIndex];
 end;
@@ -1139,7 +1139,7 @@ begin
     Exit;
   if (AType.Ref.Heap.TypeIndex >= UInt32(Length(AMap))) or
     (AMap[AType.Ref.Heap.TypeIndex] = WASM_NO_ADDR) then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: canonical type %u is not interned yet',
       [AType.Ref.Heap.TypeIndex]);
   Result.Ref.Heap.TypeIndex := AMap[AType.Ref.Heap.TypeIndex];
@@ -1202,7 +1202,7 @@ begin
   begin
     Local := ALocalBase + Member;
     if Local >= UInt32(Length(AIr.CanonTypes)) then
-      raise EWasmError.Create(
+      raise EWasmInternal.Create(
         'internal: rec group runs past the canonical type table');
 
     FTypes[ABase + Member].Comp :=
@@ -1217,7 +1217,7 @@ begin
     begin
       Source := AIr.CanonTypes[Local].Display[Entry];
       if (Source >= UInt32(Length(AMap))) or (AMap[Source] = WASM_NO_ADDR) then
-        raise EWasmError.CreateFmt(
+        raise EWasmInternal.CreateFmt(
           'internal: display entry %u is not interned yet', [Source]);
       FTypes[ABase + Member].Display[Entry] := AMap[Source];
     end;
@@ -1270,7 +1270,7 @@ begin
     end;
     if UInt64(First) + UInt64(Size) >
       UInt64(Length(AIr.TypeIndexToCanon)) then
-      raise EWasmError.Create(
+      raise EWasmInternal.Create(
         'internal: rec group sizes do not cover the type index space');
 
     LocalBase := AIr.TypeIndexToCanon[First];
@@ -1300,7 +1300,7 @@ begin
     while Member < Size do
     begin
       if LocalBase + Member >= UInt32(Length(ACanonToEngine)) then
-        raise EWasmError.Create(
+        raise EWasmInternal.Create(
           'internal: rec group runs past the canonical type table');
       ACanonToEngine[LocalBase + Member] := Base + Member;
       Inc(Member);
@@ -1313,7 +1313,7 @@ begin
   end;
 
   if First <> UInt32(Length(AIr.TypeIndexToCanon)) then
-    raise EWasmError.Create(
+    raise EWasmInternal.Create(
       'internal: rec group sizes do not cover the type index space');
 
   { B22: the collector's layout table is Define'd once per engine type, in
@@ -1322,7 +1322,7 @@ begin
     the invariant is asserted rather than assumed: every allocated engine
     type has a materialised GC layout. }
   if FGcTypes.Count <> FTypeCount then
-    raise EWasmError.CreateFmt(
+    raise EWasmInternal.CreateFmt(
       'internal: %d engine types but %d GC layouts', [FTypeCount,
       FGcTypes.Count]);
 
@@ -1345,7 +1345,7 @@ function TWasmEngine.EngineType(
   const AId: TWasmEngineTypeId): TWasmEngineType;
 begin
   if AId >= UInt32(FTypeCount) then
-    raise EWasmError.CreateFmt('internal: no engine type %u', [AId]);
+    raise EWasmInternal.CreateFmt('internal: no engine type %u', [AId]);
   Result := FTypes[AId];
 end;
 
@@ -1363,7 +1363,7 @@ begin
     match; a valid id is never WASM_NO_ADDR, so the guard rejects the
     absent case rather than letting equality answer for it. }
   if (ASub >= UInt32(FTypeCount)) or (ASuper >= UInt32(FTypeCount)) then
-    raise EWasmError.Create('internal: engine type id out of range');
+    raise EWasmInternal.Create('internal: engine type id out of range');
   if ASub = ASuper then
     Exit(True);
   SuperDepth := FTypes[ASuper].Depth;
@@ -1375,7 +1375,7 @@ function TWasmEngine.AbsKindOf(
   const AId: TWasmEngineTypeId): TWasmAbsHeapType;
 begin
   if AId >= UInt32(FTypeCount) then
-    raise EWasmError.CreateFmt('internal: no engine type %u', [AId]);
+    raise EWasmInternal.CreateFmt('internal: no engine type %u', [AId]);
   case FTypes[AId].Kind of
     wckStruct: Result := wahStruct;
     wckArray: Result := wahArray;
@@ -1843,7 +1843,7 @@ end;
 procedure CheckMemAddr(const AAddr: TWasmMemAddr; const ACount: Integer);
 begin
   if AAddr >= UInt32(ACount) then
-    raise EWasmError.CreateFmt('internal: no memory %u', [AAddr]);
+    raise EWasmInternal.CreateFmt('internal: no memory %u', [AAddr]);
 end;
 
 function TWasmStore.MemoryAddrType(
@@ -1901,7 +1901,7 @@ procedure TWasmStore.TableSet(const AAddr: TWasmTableAddr;
   const AIndex: UInt64; const ARef: TWasmRef);
 begin
   if AAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [AAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [AAddr]);
   if TableIndexOutOfBounds(Tables[AAddr], AIndex) then
     TrapNow(wtkTableOutOfBounds);
   { Root-array store: barrier BEFORE the write so a future generational
@@ -1916,7 +1916,7 @@ var
   Cursor: UInt64;
 begin
   if AAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [AAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [AAddr]);
   TableCheckRange(Tables[AAddr], AIndex, ACount);
   { One barrier for the whole fill: every stored slot takes the same
     reference, so recording that edge once is sufficient for any
@@ -1939,7 +1939,7 @@ var
   Cursor: UInt64;
 begin
   if AAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [AAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [AAddr]);
   { table.grow returns -1 on failure and does not trap. }
   OldSize := UInt64(Length(Tables[AAddr].Elems));
   if ADelta > Tables[AAddr].MaxSize - OldSize then
@@ -1979,7 +1979,7 @@ var
   Count: UInt64;
 begin
   if AAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [AAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [AAddr]);
   Count := UInt64(Length(ASrc));
   { Range check precedes any write, so a trapping table.init writes
     nothing — table.init's own semantics. }
@@ -2003,7 +2003,7 @@ begin
   { O-2 sliced form (the interpreter's table.init). BOTH sides are checked
     before any write, so a trapping table.init writes nothing. }
   if AAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [AAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [AAddr]);
   { Source range against the element instance's length; subtracting form so
     a large offset on a long slice cannot wrap. A dropped segment has
     Length 0, so any non-empty slice traps. Same message as the dest side. }
@@ -2030,9 +2030,9 @@ var
   Ref: TWasmRef;
 begin
   if ADestAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [ADestAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [ADestAddr]);
   if ASrcAddr >= UInt32(Length(Tables)) then
-    raise EWasmError.CreateFmt('internal: no table %u', [ASrcAddr]);
+    raise EWasmInternal.CreateFmt('internal: no table %u', [ASrcAddr]);
   { BOTH ranges checked before any write, trapping 'out of bounds table
     access' (exec-table.copy). The range check precedes the copy so a
     trapping table.copy leaves the destination untouched. }

--- a/source/units/Wasm.Validator.Body.pas
+++ b/source/units/Wasm.Validator.Body.pas
@@ -5088,7 +5088,7 @@ begin
     from here than from a tier: the invariant is one trailing iroReturn. }
   I := Length(FFn.Code);
   if (I = 0) or (FFn.Code[I - 1].Op <> iroReturn) then
-    raise EWasmValidationError.Create(
+    raise EWasmInternal.Create(
       'internal: function IR does not end with a return');
 
   Result := FFn;

--- a/source/units/Wasm.Validator.Types.Test.pas
+++ b/source/units/Wasm.Validator.Types.Test.pas
@@ -668,12 +668,13 @@ begin
     return. That is an internal error, and it must NOT be reported with a
     canonical prefix — a conformance runner prefix-matches those, and an
     impossible internal state dressed as `unknown type` would read as a
-    rejected module. }
+    rejected module. It surfaces as EWasmInternal, never as a validation
+    claim about a module. }
   Outcome := 'no error';
   try
     FContext.TopHeapType(MakeBotHeapType);
   except
-    on E: EWasmValidationError do
+    on E: EWasmInternal do
       if Copy(E.Message, 1, Length(MSG_UNKNOWN_TYPE)) = MSG_UNKNOWN_TYPE
       then
         Outcome := 'canonical prefix'

--- a/source/units/Wasm.Validator.Types.pas
+++ b/source/units/Wasm.Validator.Types.pas
@@ -1279,7 +1279,7 @@ begin
     runner. Without this guard the bottom sentinel falls through to
     ConcreteAbsKind and raises exactly that. }
   if IsBotHeapType(A) then
-    raise EWasmValidationError.Create(
+    raise EWasmInternal.Create(
       'internal error: TopHeapType has no answer for the bottom heap '
       + 'type; the caller must test IsBotHeapType first');
 

--- a/source/units/Wasm.Validator.pas
+++ b/source/units/Wasm.Validator.pas
@@ -175,7 +175,7 @@ const
 function GroupMemberCount(const AKey: TWasmBytes): UInt32;
 begin
   if Length(AKey) < 4 then
-    raise EWasmError.Create('internal: malformed rec-group key');
+    raise EWasmInternal.Create('internal: malformed rec-group key');
   Result := UInt32(AKey[0]) or (UInt32(AKey[1]) shl 8) or
     (UInt32(AKey[2]) shl 16) or (UInt32(AKey[3]) shl 24);
 end;
@@ -189,7 +189,7 @@ var
   procedure Need(const ACount: Integer);
   begin
     if P + ACount > Length(Buf) then
-      raise EWasmError.Create('internal: rec-group key truncated');
+      raise EWasmInternal.Create('internal: rec-group key truncated');
   end;
 
   function ReadU32: UInt32;
@@ -206,7 +206,7 @@ var
     Engine: UInt32;
   begin
     if ALocal >= UInt32(Length(ACanonToEngine)) then
-      raise EWasmError.Create(
+      raise EWasmInternal.Create(
         'internal: rec-group key names an out-of-range out-of-group type');
     Engine := ACanonToEngine[ALocal];
     { High(UInt32) is the "not interned yet" marker the caller seeds the
@@ -214,7 +214,7 @@ var
       which is always already interned, so hitting it is an invariant
       violation, not a legal state. }
     if Engine = High(UInt32) then
-      raise EWasmError.Create(
+      raise EWasmInternal.Create(
         'internal: rec-group key names an un-interned out-of-group type');
     Buf[APos] := Byte(Engine and $FF);
     Buf[APos + 1] := Byte((Engine shr 8) and $FF);
@@ -278,11 +278,11 @@ var
                 MapCanonAt(Pos, Local);
               end;
           else
-            raise EWasmError.Create('internal: bad heap tag in rec-group key');
+            raise EWasmInternal.Create('internal: bad heap tag in rec-group key');
           end;
         end;
     else
-      raise EWasmError.Create('internal: bad value tag in rec-group key');
+      raise EWasmInternal.Create('internal: bad value tag in rec-group key');
     end;
   end;
 
@@ -362,7 +362,7 @@ begin
       KEY_COMP_ARRAY:
         RewriteFieldType;
     else
-      raise EWasmError.Create('internal: bad comp tag in rec-group key');
+      raise EWasmInternal.Create('internal: bad comp tag in rec-group key');
     end;
     Inc(I);
   end;


### PR DESCRIPTION
Part 2 of 3 in stack `gh-15` (on #12). Findings CA-2 + CA-3 of the 2026-08 codebase audit.

## CA-3: `EWasmInternal`

The `"internal: ..."` raise sites (82) sit on paths the validator's type check proves unreachable for a validated module — runtime defects, not claims about a module. They now raise `EWasmInternal`, a leaf under `EWasmError`, so they can never surface as a decode/validation/link/trap claim. Hierarchy pinned by a new `Wasm.Core.Test` case; the `TopHeapType(BOT)` expectation updated to the stronger contract.

## CA-2: analysis ratchets in `lwpt.toml`

`[health]` / `[duplication]` limits set just above the measured baseline (file cyclo 1147→1200, cognitive 988→1050; routine 497→520, 182→200; duplication 9.3%→10%) so regressions fail CI instead of drifting.

## Evidence

- `lwpt build`, `lwpt test` (44 suites), `lwpt format --check`, `lwpt agents --check`: clean.
- Full corpus, interp tier: errors=0, pass=65208 on ROOT, all pinned core scripts green; failures confined to `legacy/` and `proposals/` residue.

Base: #12. Layer 3 (#14) builds on this branch.