### PR TITLE
ci(pr): run the fast gate on pull requests to any base branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,13 +14,21 @@ name: PR
 # the same release tag and are verified against the committed lockfile +
 # .lwpt/modules tree via install --frozen.
 
+# No `branches:` filter on purpose. That key matches the pull request's BASE,
+# so a stacked pull request — one whose base is the layer below it rather
+# than main — was skipped entirely (the gap stack gh-15 hit on #13/#14).
+# Every pull request runs this workflow whatever its base.
+#
+# Widening the trigger multiplies runs across a stack, so supersede rather
+# than accumulate: a new push cancels the previous run for the same pull
+# request, keeping the verdict attached to the current head.
 on:
-  # Every PR, whatever its base — native stacks give intermediate layers a
-  # non-main base branch, and the fast gate must run on those too (the
-  # workflow file a stacked PR executes comes from its own base ref, so the
-  # fix has to be on main before stacked layers can see it).
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,9 +15,11 @@ name: PR
 # .lwpt/modules tree via install --frozen.
 
 on:
+  # Every PR, whatever its base — native stacks give intermediate layers a
+  # non-main base branch, and the fast gate must run on those too (the
+  # workflow file a stacked PR executes comes from its own base ref, so the
+  # fix has to be on main before stacked layers can see it).
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Repairs the gap stack `gh-15` (#12–#14) hit: native-stack layers have an intermediate base branch, and `pr.yml`'s `branches: [main]` filter meant those PRs never got a check (`#13: no checks reported`) and the UI could not mark the top layer mergeable.

The workflow a stacked PR executes comes from its own base ref, so this must land on main before stacked layers pick it up — hence standalone rather than a stack layer.

- `pull_request:` with no branch filter; `workflow_dispatch` kept.
- Comment block updated to say why.