### PR TITLE
perf(jit): accelerate compiled loop, call, and GC hot paths

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,27 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 9: native struct field access ACCEPTED — gc −25%)
+Updated: 2026-08-22 (wave 10: StructSetSeq accepted — gc −4%/−1%)
+
+## Wave 10 — struct.new fills resolve layout once ACCEPTED (small)
+
+- Commit `bbedb4a` (`perf(gc): resolve struct.new field layout once per
+  fill`). New heap method `StructSetSeq(Ref, Values, Count)`: one null/kind/
+  bounds check and ONE LayoutOf resolution, then N direct WriteField calls —
+  replacing N per-field StructSet crossings that each re-resolved the layout
+  (the fresh profile showed 78 samples of TWasmGcTypes.Layout under
+  StructSet). Both tiers route through it for arities ≤ 8 via a stack temp;
+  larger arities keep the legacy loop. The v1 write barrier is empty by
+  design, so the sequential fill is observably identical.
+- Serialized A/B vs the true wave-9 head (ec294dd, rebuilt + hash-retained at
+  /tmp/wave9-head.ec294dd): gc −4.1%/−1.4% — small, forward-dominant, no
+  regression in 14 samples. Corpus byte-identical in all three tiers on this
+  exact tree; format green. NOTE: an earlier comparison against the WAVE-6
+  baseline read −27% — always diff against the IMMEDIATE predecessor head.
+- Post-wave-9 gc profile (for the next session): alloc family ~52%
+  (AllocStruct 558+158, TakeCell ~414, Collect/Sweep only ~170), StructSet
+  family down to ~9% after this slice, generated body ~58% — inline
+  allocation is now unambiguously the next move, exactly per wave 8's design
+  notes.
 
 ## Wave 9 — numeric struct.get/get_s/get_u/set natively on arm64 ACCEPTED
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,42 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 7: loop-header alignment REJECTED — no effect)
+Updated: 2026-08-22 (wave 8: gc profile refresh; layout memo rejected as noise)
+
+## Wave 8 — GC groundwork: fresh profile, layout memo REJECTED as noise
+
+- Refreshed `sample(1)` profile of the scaled gc workload on the current head
+  (3824 loop samples): alloc family ~23% (AllocStruct 602+200, TakeCell ~430,
+  Collect/Sweep only ~170 ≈ 5%), StructSet family ~9% (body 138,
+  **TWasmGcTypes.Layout re-resolution 85**, GcRefTypeId 37 = roots-array ref
+  barrier — inherent), IrAuxBlockItem/Count runtime reads ~140 (the array-set
+  dispatch reads aux tables per call at runtime), generated body ~43%.
+- Tried: single-entry Layout memo in TWasmGcTypes (fields FMemoId/FMemoLayout,
+  High sentinel ctor, resets in Define/Grow because SetLength reallocates).
+  Correct, all suites green — but serialized release A/B measured gc
+  −1.4%/+1.0%: flat within noise. REJECTED per the no-repeatable-delta rule;
+  reverted; binary hash back to the exact wave-6 build.
+- **PROCESS GUARD, SECOND OFFENSE**: an interim A/B compared a DEV-mode
+  candidate against the RELEASE baseline again (gc "277 ms", +164%). The
+  signature is unmistakable: compiled-tier workloads ~2.6x slow, perfectly
+  stable across legs. RULE: after ANY `lwpt build wasmlight`, a release
+  rebuild (`lwpt build --mode release`) is mandatory before any measurement;
+  check `shasum build/wasmlight` against the retained baseline binary when in
+  doubt. Consider a wrapper or hook to enforce this.
+- DESIGN GROUNDWORK for the dedicated inline-allocation session (the only
+  lane that moves gc materially): free-list pop is FFree[const class] head +
+  link load/store (~4 instrs); the blocker is SetCellAllocated's bitmap word
+  (cell = (head−Base)/CellSize, then div-32 index + variable-shift ORR ≈ 7-8
+  instrs — CellSize is compile-time constant per fixed type so magic-multiply
+  applies); ZeroCell can shrink to a tail store ONLY if nothing reads raw
+  cell bytes outside layouts (needs a design-doc proof before touching);
+  counters (FBytesLive/Allocated/ObjectCount) must still update (~6 instrs);
+  threshold-check/collect stays as THE allocation-site safepoint per
+  ADR-0011; slow path = existing helper unchanged. Estimated fast path ~25-30
+  instructions vs ~40 today including crossings — worth it only together
+  with native struct.get/array.set to also kill the crossing overhead.
+- The array.set runtime aux reads (~140 samples) are the same shape as the
+  struct.get/array.set native-template lane; bounded follow-up: bake the
+  field index/count into the emitted code for fixed-type array shapes.
 
 ## Wave 7 — fetch-alignment padding for backward targets REJECTED
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,113 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 3 candidate rejected; scalar memory + simd profiled)
+Updated: 2026-08-22 (wave 5: SIMD Q-host lane REJECTED and reverted)
+
+## Wave 5 — v128 constant Q-hosts + vector static-cache admission REJECTED
+
+- Lane built directly on wave 4's const-slot machinery: admitted
+  Arm64NativeVecOp into StaticCacheOp (vector loop functions become static-
+  cache eligible), extended AnalyzeConstSlots with iroV128Const candidates
+  (pair base slot, 128 bits from IrAuxReadV128, offered only when defined in
+  a loop span and EVERY consumer is a native vec template — helper-dispatched
+  readers would see an never-written canonical pair), seeded caller-saved
+  v16/v17 once at frame entry via two LoadImm64 + INS pairs (new builder
+  Arm64MovGeneralToVecD, imm5 = %01000 + lane<<4, verified against
+  `mov v16.d[0],x9` = 4E081D30), parameterized every EmitNativeVec source
+  load through a host-aware resolver, routed native vec ops through the
+  cached path WITHOUT flush/invalidate, and made splats consume scalar cache
+  hosts directly.
+- Generated code was correct and much smaller: the simd loop went from ~47
+  to ~28 instructions — const-B hosted in v16 (`add.4s v0,v0,v16`), limit
+  hoisted to x14, splat reading w15. Measured result was a REPEATABLE
+  REGRESSION: serialized simd-only A/B (7 samples, both orders) gave cand
+  11.455/11.489 ms vs base 9.484/9.986 ms (+17-21%, disjoint spreads); the
+  full-schedule legs agreed (+18.2%/+12.7%).
+- Root cause NOT fully identified: fewer instructions but slower — the same
+  wall wave 3 hit when admitting vector ops to the static cache. Suspected
+  residual: changed loop-body code layout/fetch alignment (backedge target
+  moved from 0x60, 16-aligned, to 0xac) and/or spill-pattern side effects of
+  scalar static allocation inside vector loops. Fully reverted; nothing
+  remains in the tree. Any retry must first explain WHY the smaller loop is
+  slower — e.g. by bisecting eligibility-admission alone vs Q-hosting alone,
+  or by measuring with forced 16-byte alignment padding before the loop
+  header.
+
+## Wave 4 — loop-invariant constants seeded once in static cache hosts
+
+- Goal for this session was "0.7x–0.85x of Wasmtime": every wasmbench
+  workload at ≥70% of Wasmtime throughput (≤1.43x time). Baseline at exact
+  `origin/main@e686e0a` (release binary sha256 `d795d942…`, retained at
+  `/tmp/wasmlight-wave4-baseline.e686e0a/`) measured, serialized under the
+  perf gate (best profile, 1 warm-up discarded, 7 samples): startup 2.47 ms,
+  loop 378/365 ms, fib 33 ms, memory 22 ms, memory-load 41→44 ms,
+  memory-store 49→36 ms, call 138→155 ms, memory-grow 13 ms, gc 106→112 ms,
+  simd 8.4→10.7 ms, host-call 35→38 ms across the four legs — i.e. failing
+  workloads were gc (~3.65x), call (~2.2x), simd (~1.9x), memory-store
+  (~1.75x time).
+- Profiles captured (`sample(1)` on long scaled AOT runs, artifacts under
+  `/var/folders/mv/6_sclnc96hgfcv9gknbsqr880000gn/T/opencode/wave4-profile/`):
+  - **gc**: ~44% generated loop body, ~37% allocation machinery
+    (AllocStruct/Allocate/TakeCell + Collect/Sweep ≈4%), ~9% StructSet helper
+    re-resolving TWasmGcTypes.Layout per set, plus InterpContextFor crossings.
+    Three helper blrs per iteration (struct.new/array.set/struct.get).
+  - **call**: 100% generated code, zero helpers. The native leaf core wastes
+    ~6 of ~13 instructions moving operands into value positions
+    (`mov x14,x12; mov x15,x13 … mov x17,x16; mov x12,x17`); the caller
+    re-resolves FuncAddrs×sizeof/entry/caps every call (~22 instructions of
+    plumbing around one blr).
+  - **simd**: two v128 constants rebuilt via 8×movz/movk + slot traffic EVERY
+    iteration, accumulator spilled/reloaded through canonical slots, scalar
+    limit rebuilt per iteration. ~37 instructions where ~6 do the work.
+  - **memory loops**: the br_if limit constant is materialized inside the
+    loop body (movz+movk+mov) every iteration because its IR instruction is.
+- Accepted commit `f191e18`
+  (`perf(jit): seed loop-invariant constants once in static cache hosts`,
+  branch `t3code/optimize-runtime-wasmtime-gap-1`): a driver analysis picks
+  up to ONE constant-defined slot (unique writer, not already allocated,
+  defined inside a backward-jump loop span, not SkipPlanned by fusion),
+  `Arm64EnableConstSlots` appends it behind the leading statics and seeds the
+  host register once at frame entry via immediate materialization, and the
+  defining const instruction then emits nothing. The dynamic victim pool is
+  now `[DynBase..DynBase+DynCount)` instead of hardcoded `[3..6]`
+  (`TArm64RegCache.DynBase/DynCount/ConstFrom`); FlushDynamicRegCache keeps
+  starting at StaticCount because native-core non-leaf mode keeps dirty
+  parameter entries below any fixed boundary — that distinction is load-
+  bearing and broke fac/fib i64 until restored. Arm64-only this wave; x64
+  inert (enable call sits in the ARM64 block), so x86-64 corpus identity was
+  trivially preserved but must be proven in the VM before any PR.
+- Serialized release A/B BASE-CAND-CAND-BASE under `/tmp/wasmlight-perf-gate.lock`
+  (7 samples each leg, raw JSON in `/tmp/ab2/*.json`): loop −3.8%/−3.8%
+  (367.5/367.0 → 353.4/352.9 ms, disjoint spreads); all other guards flat:
+  fib +0.9/+0.4, memory-load +2.6/−6.0, memory-store −2.7/+4.8, gc
+  +1.1/−0.5, simd −1.4/+0.3, host-call +2.3/+0.6, grow/startup flat. The
+  call reverse-leg median (+19%) was background host load — its samples are
+  bimodal (136–192 ms) while both clean legs cluster 127–155.
+- REJECTED variant: two const slots (K=2). Same schedule measured loop
+  −5.5%/−6.7% BUT memory-load +21.8%/+8.7% in BOTH orders — appending a
+  second host shrinks the dynamic pool to two registers and the load loop's
+  expression pressure thrashes. Fully reverted before acceptance; do not
+  re-attempt without a pressure-aware gate.
+- PROCESS NOTE: an intermediate A/B compared a DEV-mode candidate against
+  the RELEASE baseline (gc +173%, host-call +165%) — build modes must match
+  on both sides of every comparison; dev builds are correctness gates only.
+- Correctness on the accepted head (release `76eb3fd0…`): frozen install,
+  format, agents check green; 44/44 unit suites; corpus byte-identical in
+  interpreter/JIT/AOT at pass=65851 fail=368 skip=904 staged=0 errors=0
+  (compiled=8799); Markdown lint clean.
+- Band status after the wave (same-schedule Wasmtime medians): IN BAND
+  startup 0.64x, loop 1.05x, fib 0.99x, memory 1.13x, memory-grow 0.99x,
+  host-call 0.92x; BORDERLINE memory-load ~1.36x / memory-store ~1.34x
+  (inside 1.43x but not improved by this lane — they are store/load
+  bandwidth-bound, instruction removal hides under latency); OUT OF BAND
+  simd ~1.87x, call ~2.2x, gc ~3.8x.
+- Next lanes, pre-seeded with profile evidence above: (1) GC native inline
+  allocation fast path in both backends (bump/free-list inline, collect
+  slow path as the allocation-site safepoint per ADR-0011) — largest gap;
+  (2) SIMD Q-register caching of vector values + v128 constant hoisting for
+  call-free functions (wave-3's counter-caching variant failed; Q-value
+  caching remains unbuilt machinery in both backends); (3) native scalar
+  leaf-core operand cleanup (consume x12/x13 in place, produce x12) plus
+  hoisting direct-call metadata resolution across backedges.
 
 ## Wave 3 — static cache for vector loops REJECTED and reverted
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,45 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 10: StructSetSeq accepted — gc −4%/−1%)
+Updated: 2026-08-22 (wave 11 scoping: inline-alloc design RESOLVED, not built)
+
+## Wave 11 — inline struct.new allocation: design finalized, execution deferred
+
+- Scoping pass produced every remaining design answer; implementation did
+  not start (GC-critical surface + late-session budget). Build order for the
+  dedicated session:
+  1. PROBES: mirror WasmJitFrameOffsets' uninitialized-local address trick.
+     Needed: (a) Gc-unit probe for TWasmGcHeap privates {FFree[0] base,
+     FMarkState, FBytesLive, FBytesAllocated, ObjectCount}; (b) Store-unit
+     probe for {TWasmStore.FHeap} and {TWasmModuleInstance.EngineTypeIds} —
+     both classes, so the probe constructs a throwaway Engine/Store/Instance,
+     takes field addresses, frees, caches lazily. Block-field offsets
+     (Base@8, Allocated dyn-array ptr) are computable in the backend directly
+     if TWasmGcBlock is interface-visible (verify).
+  2. ENTRY ABI DECISION (pick one): load the runtime engine type id via the
+     context chain (~7 instructions per alloc: ctx.Acts[Depth-1].Instance.
+     EngineTypeIds[idx]; all offsets already probed except EngineTypeIds),
+     OR pass Instance as a new compiled-entry argument (x5) — cleaner code
+     but bumps the entry ABI fingerprint (fails old artifacts closed) and
+     touches both InvokeCompiled marshals + AOT wiring.
+  3. FAST PATH (free-list hit ONLY; miss → existing AllocStruct dispatch
+     sequence emitted inline as the slow branch — it remains THE collect
+     safepoint per ADR-0011): head = [heap+FFree0+cls*8]; cbz → slow; pop
+     link; bitmap word |= bit (cell = diff >> log2CellSize — POW2 CLASSES
+     ONLY initially, {16,32,64,128,256}, others decline to helper); tail
+     zero ≤ 8 bytes (decline larger); header := markState | kindConst<<2 |
+     typeId<<32; counters BytesLive/BytesAllocated += CellSize, ObjectCount++
+     (~7 instrs, non-negotiable); numeric field stores at baked offsets
+     (truncating strb/strh like WriteField); publish Dest last.
+  4. DECLINES: any ref field (barrier shape), v128 field, non-pow2 cell,
+     tail > 8, struct.new_default (defaults loop differs).
+  5. GATES: differential gc module exercising free-list reuse across a
+     forced collect; corpus ×3 tiers; byte-pin test for the sequence.
+- ZeroCell shrink question remains open (needs the nothing-reads-raw-bytes
+  proof) but is INDEPENDENT: fast path can keep full ZeroCell semantics by
+  simply declining to skip it (zeroing stays in the slow path; fast path
+  writes header+fields over recycled bytes whose stale content is only
+  reachable through fields it immediately overwrites or tail bytes it
+  zeroes — write the argument down either way).
 
 ## Wave 10 — struct.new fills resolve layout once ACCEPTED (small)
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,36 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 8: gc profile refresh; layout memo rejected as noise)
+Updated: 2026-08-22 (wave 9: native struct field access ACCEPTED — gc −25%)
+
+## Wave 9 — numeric struct.get/get_s/get_u/set natively on arm64 ACCEPTED
+
+- Commit `ec294dd` (`perf(jit): emit numeric struct field access natively on
+  arm64`). The driver's AnalyzeGcFieldAccess mirrors TWasmGcTypes' layout
+  math exactly (header 8, per-field align-up to storage width, cumulative
+  advance) over AIr.CanonTypes[TypeIndexToCanon[Imm.hi]].Comp, baking offset/
+  width/signedness into a per-instruction shape word (bit0 native, bit1
+  signed, bits8-15 width, bits16-31 offset). Ref fields and v128 stay on the
+  helper path (write barrier / Q regs); offsets that do not fit the scaled
+  imm12 decline. Arm64EmitGcFieldAccess emits: cached ref load → cbnz past a
+  type-specific null trap (`wtkNullStructReference`, same kind and position
+  as the helper) → width-sized load with sign/zero extension or width-sized
+  store from the value's cache host. No engine ids are baked — offsets are
+  pure functions of the module composite, so AOT artifacts stay
+  instance/store-agnostic.
+- Emitted shape per access ≈ 5 instructions replacing a full helper crossing
+  plus internal layout resolution. Verified by carve: `ldrsb w10,[x9,#24]`
+  for an i8 get_s at baked offset 24.
+- Serialized release A/B vs the wave-6 baseline binary: gc **−24.8%/−25.2%**
+  (101.2/101.5 → 76.1/75.9 ms; spreads fully disjoint). gc/Wasmtime ratio
+  improves from ~3.5x to ~2.6x. All other workloads untouched (shapes fire
+  only for struct ops).
+- Correctness: 44/44 suites; corpus byte-identical interp/JIT/AOT at
+  pass=65851 fail=368 skip=904 staged=0 errors=0 (compiled=8799); format
+  green. x64 inert (shape array only passed to the arm64 call site).
+- Follow-ups in priority order: (1) native struct.new allocation fast path
+  per wave 8's design notes (now the largest remaining gc cost); (2) native
+  array.get/set with baked element offsets + bounds check (kills the runtime
+  IrAux reads ~140 samples and another crossing); (3) x64 mirror of both.
 
 ## Wave 8 — GC groundwork: fresh profile, layout memo REJECTED as noise
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,25 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 6: native-core param forwarding + in-place consts)
+Updated: 2026-08-22 (wave 7: loop-header alignment REJECTED — no effect)
+
+## Wave 7 — fetch-alignment padding for backward targets REJECTED
+
+- Tested wave 5's residual theory directly: pad every backward-jump target
+  (loop header) to a 16-byte boundary with A64 NOPs before BindLabel, so
+  iterations enter on a full decode window. Semantically transparent — corpus
+  identity held immediately (65851/368/904 in jit); one shape-pin test grew
+  by the two NOP words as expected.
+- Clean-environment serialized A/B (after catching and stopping a UTM/QEMU
+  Windows VM that had been eating ~176% CPU and poisoning several earlier
+  legs — always `ps aux -r` before trusting a schedule): loop −0.6%/−0.2%,
+  simd +2.4%/−2.2%, fib/memory flat, memory-store unmeasurable (its samples
+  are bimodal 27–49 ms even within one leg on this host). No repeatable
+  positive delta → reverted; binary hash back to the exact wave-6 build.
+- CONSEQUENCE FOR WAVE 5: simple loop-header alignment does NOT explain why
+  the smaller vector loop measured slower. The simd retry needs a real
+  microarchitectural bisect (candidates: scalar-static allocation inside vec
+  functions forcing value slot round-trips; Q-bank effects; per-op cache
+  invalidation patterns). Do not re-attempt on the alignment theory.
 
 ## Wave 6 — leaf-core operand cleanup ACCEPTED
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,35 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 5: SIMD Q-host lane REJECTED and reverted)
+Updated: 2026-08-22 (wave 6: native-core param forwarding + in-place consts)
+
+## Wave 6 — leaf-core operand cleanup ACCEPTED
+
+- Two contained changes on top of f191e18, commit `6187bae`
+  (`perf(jit): forward native-core param aliases and emit consts in place`):
+  1. AnalyzeLocalAliases' gate widened from `(UsePinnedMemoryBase and
+     UseStaticCache)` to also admit `UseNativeScalarCore` — the pass already
+     forwarded local.get-moves into consumers for memory loops; closed
+     native-scalar cores have the identical proof shape (helper-free,
+     params in fixed hosts, one-use temps). ImmediateFusion and
+     StoreLoadForwarding keep their narrower gates deliberately.
+  2. Cached iro*Const emission now reserves its destination victim first
+     (Arm64CachedDestReg) and materializes the immediate directly into it,
+     removing the T0→victim mov hop per constant in write-back mode.
+- Evidence: carved leaf core of a two-arg LCG leaf shrank 14 → 9
+  instructions (`eor w14,w12,w13` consumes ABI regs directly; consts land in
+  value positions); remaining double-bounce (`mov x15,x14; mov x12,x15`) is
+  blocked by the x12 fixed-mapping conflict (result reg cannot share the
+  param's cache slot) — needs a result-register mapping design if pursued.
+- Serialized A/B under load (host ~3x slower than usual during this run —
+  absolute medians inflated equally on both sides, relative deltas valid):
+  fib(35) **−10.3%/−8.2%**, call −2.9%/−2.4%, both orders consistent.
+  Fib gains most because self-recursion executes the cleaned core.
+- Wasm.Jit.Arm64.Test's dynamic-write-back test re-pinned to the tighter
+  emission (28 bytes dead / 32 bytes one-spill, spill word at index 6).
+- x64 inert: the widened gate sits inside the ARM64 ifdef.
+- Next call-lane step (unbuilt): hoist per-call target/cap resolution across
+  backedges for proof-gated direct calls to compiled leaves — caller-side
+  plumbing (~22 instructions around each blr) dominates over the callee now.
 
 ## Wave 5 — v128 constant Q-hosts + vector static-cache admission REJECTED
 

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -1421,6 +1421,7 @@ var
   Fn: PWasmIrFunction;
   Obj: TWasmRef;
   N, I: UInt32;
+  TmpFields: array[0..7] of TWasmValue;
 begin
   Store := ACtx^.Store;
   Reg := Frame(ACtx^.Values, AAct^.Base);
@@ -1428,11 +1429,21 @@ begin
   Obj := Store.Heap.AllocStruct(AAct^.Instance.EngineTypeIds[UInt32(AIns^.Imm)]);
   Reg[AIns^.Dest].Bits := UInt64(Obj);            { publish before filling }
   N := IrAuxBlockCount(Fn^.AuxU32, AIns^.A);
-  I := 0;
-  while I < N do
+  if N <= UInt32(Length(TmpFields)) then
   begin
-    Store.Heap.StructSet(Obj, I, Reg[IrAuxBlockItem(Fn^.AuxU32, AIns^.A, I)]);
-    Inc(I);
+    for I := 0 to Integer(N) - 1 do
+      TmpFields[I] := Reg[IrAuxBlockItem(Fn^.AuxU32, AIns^.A, I)];
+    Store.Heap.StructSetSeq(Obj, @TmpFields[0], N);
+  end
+  else
+  begin
+    I := 0;
+    while I < N do
+    begin
+      Store.Heap.StructSet(Obj, I,
+        Reg[IrAuxBlockItem(Fn^.AuxU32, AIns^.A, I)]);
+      Inc(I);
+    end;
   end;
 end;
 

--- a/source/units/Wasm.Jit.Arm64.Test.pas
+++ b/source/units/Wasm.Jit.Arm64.Test.pas
@@ -447,8 +447,9 @@ begin
         MakeIrInstr(iroI32Const, UInt32(I + 2), 0, 0, I), Aux,
         UInt32(I), False, False, False, False, Cache)).ToBe(True);
     { The fifth value evicts the first after its last use count reached zero.
-      Two static loads plus two words per constant: no canonical spill. }
-    Expect<Integer>(Buf.Size).ToBe(12 * SizeOf(UInt32));
+      Two static loads plus one word per constant — the immediate lands
+      directly in the freshly reserved victim, no T0 hop. }
+    Expect<Integer>(Buf.Size).ToBe(7 * SizeOf(UInt32));
   finally
     Buf.Free;
   end;
@@ -465,10 +466,11 @@ begin
       Expect<Boolean>(Arm64EmitOpCached(Buf,
         MakeIrInstr(iroI32Const, UInt32(I + 2), 0, 0, I), Aux,
         UInt32(I), False, False, False, False, Cache)).ToBe(True);
-    { Slot 2 still has a future use, so its eviction writes one canonical
-      value before x14 is reassigned. }
-    Expect<Integer>(Buf.Size).ToBe(13 * SizeOf(UInt32));
-    Expect<UInt32>(EmittedWord(Buf, 11)).ToBe(
+    { Slot 2 still has a future use; five constants rotate through four
+      victims, so exactly one eviction spills it (word 6) before its host is
+      reassigned to the fifth constant. }
+    Expect<Integer>(Buf.Size).ToBe(8 * SizeOf(UInt32));
+    Expect<UInt32>(EmittedWord(Buf, 6)).ToBe(
       Arm64StrX(ARM64_REG_CACHE2, ARM64_REG_REGFILE,
         Arm64SlotByteOffset(2)));
   finally

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -987,20 +987,26 @@ begin
       begin
         { A loop-invariant constant with a dedicated static host was seeded at
           frame entry; re-emitting it inside the loop body would rebuild the
-          same bits on every iteration. }
+          same bits on every iteration. Otherwise materialize straight into
+          the freshly reserved destination — the T0 hop costs an extra mov
+          per constant in the native-core shapes. }
         if not Arm64ConstSlotHost(ACache, AIns.Dest, ConstHost) then
         begin
-          Arm64EmitLoadImm32(ABuf, ARM64_REG_T0,
+          Dest := Arm64CachedDestReg(ABuf, ACache, AIns.Dest,
+            ARM64_REG_ZR, ARM64_REG_ZR, ARM64_REG_T0);
+          Arm64EmitLoadImm32(ABuf, Dest,
             UInt32(AIns.Imm and $FFFFFFFF));
-          Arm64CachedStore(ABuf, ACache, ARM64_REG_T0, AIns.Dest);
+          Arm64CachedStore(ABuf, ACache, Dest, AIns.Dest);
         end;
       end;
     iroI64Const, iroF64Const:
       begin
         if not Arm64ConstSlotHost(ACache, AIns.Dest, ConstHost) then
         begin
-          Arm64EmitLoadImm64(ABuf, ARM64_REG_T0, UInt64(AIns.Imm));
-          Arm64CachedStore(ABuf, ACache, ARM64_REG_T0, AIns.Dest);
+          Dest := Arm64CachedDestReg(ABuf, ACache, AIns.Dest,
+            ARM64_REG_ZR, ARM64_REG_ZR, ARM64_REG_T0);
+          Arm64EmitLoadImm64(ABuf, Dest, UInt64(AIns.Imm));
+          Arm64CachedStore(ABuf, ACache, Dest, AIns.Dest);
         end;
       end;
     iroBranchIf, iroBranchIfNot:

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -128,6 +128,15 @@ type
     UseCounts: PUInt32;
     VisibleSlots: PBoolean;
     SlotCount: UInt32;
+    { Dynamic (round-robin victim) entries live at [DynBase .. DynBase+DynCount-1].
+      Constant slots appended behind the leading statics raise StaticCount and
+      shrink this range, so every dynamic-range loop derives from it rather
+      than assuming the original four-register pool. }
+    DynBase: Byte;
+    DynCount: Byte;
+    { First index owned by EnableConstSlots; below it sit the ordinary statics
+      whose defining instructions must always emit. High value = none. }
+    ConstFrom: Byte;
   end;
 
   TArm64WordBin = function(const ARd, ARn, ARm: Byte): UInt32;
@@ -504,6 +513,11 @@ function Arm64EmitOp(const ABuf: TWasmCodeBuffer;
 procedure Arm64InitRegCache(out ACache: TArm64RegCache);
 procedure Arm64EnableStaticRegCache(const ABuf: TWasmCodeBuffer;
   var ACache: TArm64RegCache; const ASlots: array of UInt32);
+procedure Arm64EnableConstSlots(const ABuf: TWasmCodeBuffer;
+  var ACache: TArm64RegCache; const ASlots: array of UInt32;
+  const ABits: array of UInt64);
+function Arm64ConstSlotHost(const ACache: TArm64RegCache;
+  const ASlot: UInt32; out AHost: Byte): Boolean;
 procedure Arm64EnableDynamicWriteBack(var ACache: TArm64RegCache;
   const AUseCounts: PUInt32; const AVisibleSlots: PBoolean;
   const ASlotCount: UInt32);
@@ -944,6 +958,7 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
 var
   Source, Dest: Byte;
   ArgSlot, ResultSlot: UInt32;
+  ConstHost: Byte;
 begin
   Result := True;
   if Arm64ScalarMemoryOp(AIns.Op) then
@@ -970,14 +985,23 @@ begin
       end;
     iroI32Const, iroF32Const:
       begin
-        Arm64EmitLoadImm32(ABuf, ARM64_REG_T0,
-          UInt32(AIns.Imm and $FFFFFFFF));
-        Arm64CachedStore(ABuf, ACache, ARM64_REG_T0, AIns.Dest);
+        { A loop-invariant constant with a dedicated static host was seeded at
+          frame entry; re-emitting it inside the loop body would rebuild the
+          same bits on every iteration. }
+        if not Arm64ConstSlotHost(ACache, AIns.Dest, ConstHost) then
+        begin
+          Arm64EmitLoadImm32(ABuf, ARM64_REG_T0,
+            UInt32(AIns.Imm and $FFFFFFFF));
+          Arm64CachedStore(ABuf, ACache, ARM64_REG_T0, AIns.Dest);
+        end;
       end;
     iroI64Const, iroF64Const:
       begin
-        Arm64EmitLoadImm64(ABuf, ARM64_REG_T0, UInt64(AIns.Imm));
-        Arm64CachedStore(ABuf, ACache, ARM64_REG_T0, AIns.Dest);
+        if not Arm64ConstSlotHost(ACache, AIns.Dest, ConstHost) then
+        begin
+          Arm64EmitLoadImm64(ABuf, ARM64_REG_T0, UInt64(AIns.Imm));
+          Arm64CachedStore(ABuf, ACache, ARM64_REG_T0, AIns.Dest);
+        end;
       end;
     iroBranchIf, iroBranchIfNot:
       begin
@@ -3149,6 +3173,10 @@ end;
 procedure Arm64InitRegCache(out ACache: TArm64RegCache);
 begin
   FillChar(ACache, SizeOf(ACache), 0);
+  { The original dynamic pool is x14..x17 (entries 3..6). }
+  ACache.DynBase := 3;
+  ACache.DynCount := 4;
+  ACache.ConstFrom := High(Byte);
 end;
 
 procedure Arm64EnableStaticRegCache(const ABuf: TWasmCodeBuffer;
@@ -3166,6 +3194,55 @@ begin
       LdX(ABuf, Arm64CacheHostReg(ACache.StaticCount), ASlots[I]);
       Inc(ACache.StaticCount);
   end;
+end;
+
+{ Append loop-invariant constant slots behind the leading statics. Each host
+  register is seeded ONCE with its immediate at frame entry; the defining
+  const instruction emits nothing, so a value that sat inside the loop body
+  stops being rebuilt on every iteration. }
+procedure Arm64EnableConstSlots(const ABuf: TWasmCodeBuffer;
+  var ACache: TArm64RegCache; const ASlots: array of UInt32;
+  const ABits: array of UInt64);
+var
+  I: Integer;
+begin
+  if not ACache.StaticAllocation then
+    Exit;
+  ACache.ConstFrom := ACache.StaticCount;
+  for I := 0 to High(ASlots) do
+  begin
+    if (I > High(ABits)) or (ASlots[I] = High(UInt32)) or
+      (ACache.StaticCount > High(ACache.Entries)) then
+      Continue;
+    Arm64EmitLoadImm64(ABuf, Arm64CacheHostReg(ACache.StaticCount), ABits[I]);
+    ACache.Entries[ACache.StaticCount].Valid := True;
+    ACache.Entries[ACache.StaticCount].Slot := ASlots[I];
+    Inc(ACache.StaticCount);
+  end;
+  ACache.DynBase := ACache.StaticCount;
+  ACache.DynCount := Byte(High(ACache.Entries) + 1 - ACache.DynBase);
+  { The round-robin cursor ranged over the old four-register pool. }
+  if ACache.Next >= ACache.DynCount then
+    ACache.Next := 0;
+end;
+
+{ True when ASlot is served by one of the appended constant entries; the
+  defining iro*Const may then emit nothing. Slot numbers are unique per SSA
+  value, and the driver never hands an already-allocated slot here, so a hit
+  is unambiguous. }
+function Arm64ConstSlotHost(const ACache: TArm64RegCache;
+  const ASlot: UInt32; out AHost: Byte): Boolean;
+var
+  I: Integer;
+begin
+  Result := False;
+  for I := ACache.ConstFrom to ACache.StaticCount - 1 do
+    if ACache.Entries[I].Valid and (ACache.Entries[I].Slot = ASlot) then
+    begin
+      AHost := Arm64CacheHostReg(I);
+      Result := True;
+      Exit;
+    end;
 end;
 
 procedure Arm64EnableDynamicWriteBack(var ACache: TArm64RegCache;
@@ -3195,6 +3272,9 @@ begin
       older fixed mapping would win the next lookup. }
     ACache.StaticCount := Byte(AParamCount);
   end;
+  { The victim pool stays x14..x17 in both modes: entry 2 (x26) is reserved by
+    the self-recursion budget ABI, and the parameter entries are served by
+    their fixed hosts, never round-robin. }
   ACache.Entries[0].Valid := True;
   ACache.Entries[0].Dirty := True;
   ACache.Entries[0].Slot := AParam0Slot;
@@ -3239,6 +3319,10 @@ var
 begin
   if not ACache.WriteBackDynamics then
     Exit;
+  { Starts at StaticCount, not DynBase: in native-core modes the dirty
+    parameter entries sit below any fixed boundary and depend on this spill
+    for their canonical write-back; ordinary statics are flushed by
+    FlushRegCache instead. }
   for I := ACache.StaticCount to High(ACache.Entries) do
     Arm64SpillCacheEntry(ABuf, ACache, I);
 end;
@@ -3269,7 +3353,7 @@ var
 begin
   if ACache.StaticAllocation then
   begin
-    for I := 3 to High(ACache.Entries) do
+    for I := ACache.DynBase to High(ACache.Entries) do
       ACache.Entries[I].Valid := False;
     ACache.Next := 0;
     Exit;
@@ -3303,8 +3387,8 @@ begin
     end;
   if ACache.StaticAllocation then
   begin
-    Victim := 3 + ACache.Next;
-    ACache.Next := Byte((ACache.Next + 1) and 3);
+    Victim := ACache.DynBase + ACache.Next;
+    ACache.Next := Byte((ACache.Next + 1) mod ACache.DynCount);
   end
   else
   begin
@@ -3355,8 +3439,8 @@ begin
     { A one-source cached operation can load a missing expression directly
       into its selected dynamic entry. This is the same round-robin victim and
       liveness spill used by CachedLoad, without an unnecessary scratch copy. }
-    Victim := 3 + ACache.Next;
-    ACache.Next := Byte((ACache.Next + 1) and 3);
+    Victim := ACache.DynBase + ACache.Next;
+    ACache.Next := Byte((ACache.Next + 1) mod ACache.DynCount);
     if ACache.WriteBackDynamics then
       Arm64SpillCacheEntry(ABuf, ACache, Victim);
     Result := Arm64CacheHostReg(Victim);
@@ -3468,7 +3552,7 @@ begin
   { Reuse an established dynamic destination only when it is not an operand.
     If it is an operand, retain the scratch path so the input survives until
     the instruction has read it and no duplicate slot mapping is created. }
-  for I := 3 to High(ACache.Entries) do
+  for I := ACache.DynBase to High(ACache.Entries) do
     if ACache.Entries[I].Valid and (ACache.Entries[I].Slot = ASlot) then
     begin
       Host := Arm64CacheHostReg(I);
@@ -3480,10 +3564,10 @@ begin
   { Reserve a non-source entry before emission. Its previous value is spilled
     through the existing liveness predicate; CachedStore marks the new value
     dirty after the instruction writes it. }
-  for Attempt := 0 to 3 do
+  for Attempt := 0 to ACache.DynCount - 1 do
   begin
-    Offset := (Integer(ACache.Next) + Attempt) and 3;
-    I := 3 + Offset;
+    Offset := (Integer(ACache.Next) + Attempt) mod ACache.DynCount;
+    I := ACache.DynBase + Offset;
     Host := Arm64CacheHostReg(I);
     if (Host = AExclude0) or (Host = AExclude1) then
       Continue;
@@ -3492,7 +3576,7 @@ begin
     ACache.Entries[I].Valid := True;
     ACache.Entries[I].Dirty := False;
     ACache.Entries[I].Slot := ASlot;
-    ACache.Next := Byte((Offset + 1) and 3);
+    ACache.Next := Byte((Offset + 1) mod ACache.DynCount);
     Exit(Host);
   end;
 end;
@@ -3523,8 +3607,8 @@ begin
       StX(ABuf, ASrc, ASlot);
     if Victim < ACache.StaticCount then
     begin
-      Victim := 3 + ACache.Next;
-      ACache.Next := Byte((ACache.Next + 1) and 3);
+      Victim := ACache.DynBase + ACache.Next;
+      ACache.Next := Byte((ACache.Next + 1) mod ACache.DynCount);
     end;
     if ACache.WriteBackDynamics then
       Arm64SpillCacheEntry(ABuf, ACache, Victim);

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -2026,6 +2026,7 @@ var
   Fn: PWasmIrFunction;
   Obj: TWasmRef;
   N, I, U1, U2, TypeIdx, DataIdx, ElemIdx, Aux: UInt32;
+  TmpFields: array[0..7] of TWasmValue;
   ElemOffset, Count, SrcLen: UInt32;
   DataAddr: TWasmDataAddr;
   ElemAddr: TWasmElemAddr;
@@ -2039,12 +2040,21 @@ begin
         Obj := AStore.Heap.AllocStruct(Inst.EngineTypeIds[UInt32(AIns^.Imm)]);
         Reg[AIns^.Dest].Bits := UInt64(Obj);            { publish before fill }
         N := IrAuxBlockCount(Fn^.AuxU32, AIns^.A);
-        I := 0;
-        while I < N do
+        if N <= UInt32(Length(TmpFields)) then
         begin
-          AStore.Heap.StructSet(Obj, I,
-            Reg[IrAuxBlockItem(Fn^.AuxU32, AIns^.A, I)]);
-          Inc(I);
+          for I := 0 to Integer(N) - 1 do
+            TmpFields[I] := Reg[IrAuxBlockItem(Fn^.AuxU32, AIns^.A, I)];
+          AStore.Heap.StructSetSeq(Obj, @TmpFields[0], N);
+        end
+        else
+        begin
+          I := 0;
+          while I < N do
+          begin
+            AStore.Heap.StructSet(Obj, I,
+              Reg[IrAuxBlockItem(Fn^.AuxU32, AIns^.A, I)]);
+            Inc(I);
+          end;
         end;
       end;
     iroStructNewDefault:

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -107,6 +107,13 @@ type
     and lets every other internal error surface loudly (jit-spec §4.3). }
   EWasmJitBranchRange = class(EWasmError);
 
+  { Per-instruction native-shape words handed over by the driver's
+    AnalyzeGcFieldAccess; indexed by IR instruction index. }
+  TArm64GcShapeArray = array[0..$FFFFFF] of UInt64;
+  PArm64GcShapeArray = ^TArm64GcShapeArray;
+
+  PArm64RegCache = ^TArm64RegCache;
+
   TArm64RegCacheEntry = record
     Valid: Boolean;
     Dirty: Boolean;
@@ -540,7 +547,14 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
   AUsePinnedMemoryBase, AExtendedFrame, ANativeScalarSelf: Boolean;
   const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
   const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
-  var ACache: TArm64RegCache): Boolean; overload;
+  var ACache: TArm64RegCache;
+  const AGcShapes: PArm64GcShapeArray = nil): Boolean; overload;
+{ Numeric struct field access with a baked byte offset — the layout math is
+  mirrored in the driver's AnalyzeGcFieldAccess, so no runtime resolution
+  remains. Null refs trap the struct-specific kind before any load. }
+procedure Arm64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AShape: UInt64;
+  var ACache: TArm64RegCache);
 function Arm64CanUseI32Immediate(const AOp: TWasmIrOp;
   const AValue: UInt32): Boolean;
 function Arm64EmitOpCachedImmediate(const ABuf: TWasmCodeBuffer;
@@ -945,7 +959,80 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
 begin
   Result := Arm64EmitOpCached(ABuf, AIns, AAux, AInsIndex, AAddr64,
     AUsePinnedMemory, AUsePinnedMemoryBase, AExtendedFrame, False, 0, 0, 0,
-    0, 0, ACache);
+    0, 0, ACache, nil);
+end;
+
+procedure Arm64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AShape: UInt64;
+  var ACache: TArm64RegCache);
+var
+  Offset: UInt32;
+  Width, AccessSize: Byte;
+  LdrOp, StrOp: UInt32;
+  Signed: Boolean;
+  Val: Byte;
+  GoodLabel: TWasmJitLabel;
+
+  function LoadWord(const APrefix: UInt32; const ARt, ARn: Byte;
+    const AOffset: UInt32): UInt32;
+  begin
+    { Unsigned-offset form: imm12 is scaled by the access size. }
+    Result := APrefix or ((AOffset div AccessSize) shl 10)
+      or (UInt32(ARn) shl 5) or ARt;
+  end;
+
+begin
+  Offset := UInt32(AShape shr 16);
+  Width := Byte((AShape shr 8) and $FF);
+  Signed := (AShape and 2) <> 0;
+  AccessSize := Width;
+
+  { The reference arrives in a value slot; T0 carries it for the null check
+    and stays the base address. }
+  Arm64CachedLoad(ABuf, ACache, ARM64_REG_T0, AIns.A);
+  GoodLabel := ABuf.NewLabel;
+  EmitCbnzTo(ABuf, ARM64_REG_T0, GoodLabel);
+  Arm64EmitLoadImm32(ABuf, 0, Ord(wtkNullStructReference));
+  Arm64EmitCallHelper(ABuf, aohTrapKind);
+  ABuf.BindLabel(GoodLabel);
+
+  case AIns.Op of
+    iroStructGet, iroStructGetS, iroStructGetU:
+      begin
+        if Width = 1 then
+          if Signed then
+            LdrOp := $39C00000
+          else
+            LdrOp := $39400000
+        else if Width = 2 then
+          if Signed then
+            LdrOp := $79C00000
+          else
+            LdrOp := $79400000
+        else if Width = 4 then
+          LdrOp := $B9400000
+        else
+          LdrOp := $F9400000;
+        ABuf.EmitU32(LoadWord(LdrOp, ARM64_REG_T1, ARM64_REG_T0, Offset));
+        { W-form loads zero the high half, which is exactly the canonical
+          slot rule; the x load fills it verbatim. }
+        StX(ABuf, ARM64_REG_T1, AIns.Dest);
+      end;
+    iroStructSet:
+      begin
+        Val := Arm64CachedSourceReg(ABuf, ACache, AIns.B,
+          ARM64_REG_T1);
+        if Width = 1 then
+          StrOp := $39000000
+        else if Width = 2 then
+          StrOp := $79000000
+        else if Width = 4 then
+          StrOp := $B9000000
+        else
+          StrOp := $F9000000;
+        ABuf.EmitU32(LoadWord(StrOp, Val, ARM64_REG_T0, Offset));
+      end;
+  end;
 end;
 
 function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
@@ -954,7 +1041,8 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
   AUsePinnedMemoryBase, AExtendedFrame, ANativeScalarSelf: Boolean;
   const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
   const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
-  var ACache: TArm64RegCache): Boolean; overload;
+  var ACache: TArm64RegCache;
+  const AGcShapes: PArm64GcShapeArray): Boolean; overload;
 var
   Source, Dest: Byte;
   ArgSlot, ResultSlot: UInt32;
@@ -1133,6 +1221,12 @@ begin
     iroI64Rotr: Arm64CachedAlu(ABuf, AIns, @Arm64RorvX, ACache);
   else
   begin
+    if (AGcShapes <> nil) and
+      ((AGcShapes[AInsIndex] and 1) <> 0) then
+    begin
+      Arm64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
+      Exit;
+    end;
     { Helpers, safepoints, complex control and currently uncached templates all
       observe/write the canonical memory register file. }
     Arm64FlushDynamicRegCache(ABuf, ACache);

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -484,6 +484,7 @@ var
   UseThirdStatic: Boolean;
   ConstSlots: array[0..0] of UInt32;
   ConstSlotBits: array[0..0] of UInt64;
+  GcShapes: array of UInt64;
   UsePinnedMemory: Boolean;
   UsePinnedMemoryBase: Boolean;
   PinnedMemoryIndex: UInt32;
@@ -1489,6 +1490,103 @@ var
     end;
   end;
 
+  { Numeric struct.get/get_s/get_u/set bake their field offset instead of
+    paying a helper crossing that re-resolves the layout per access. The
+    offset mirrors TWasmGcTypes' layout math exactly (header, per-field
+    align-up to storage width, cumulative advance); ref fields stay on the
+    helper path because stores need the write barrier. }
+  procedure AnalyzeGcFieldAccess;
+  var
+    K, F, CanonIdx: Integer;
+    TargetIdx, FieldIdx, Offset, Width: UInt32;
+    IsRef, IsPacked: Boolean;
+    PackedKind: TWasmPackedType;
+    Comp: ^TWasmCompType;
+
+    function StorageWidthOf(const AStorage: TWasmStorageType): UInt32;
+    begin
+      if AStorage.IsPacked then
+      begin
+        if AStorage.PackedType = wpkI8 then
+          Result := 1
+        else
+          Result := 2;
+        Exit;
+      end;
+      case AStorage.ValueType.Kind of
+        wvkNum:
+          if (AStorage.ValueType.Num = wntI32) or
+            (AStorage.ValueType.Num = wntF32) then
+            Result := 4
+          else
+            Result := 8;
+        wvkVec:
+          Result := 16;
+      else
+        Result := 8;
+      end;
+    end;
+
+  begin
+    SetLength(GcShapes, Length(AFn^.Code));
+    for K := 0 to High(AFn^.Code) do
+      GcShapes[K] := 0;
+    for K := 0 to High(AFn^.Code) do
+    begin
+      if not ((AFn^.Code[K].Op = iroStructGet) or
+        (AFn^.Code[K].Op = iroStructGetS) or
+        (AFn^.Code[K].Op = iroStructGetU) or
+        (AFn^.Code[K].Op = iroStructSet)) then
+        Continue;
+      IrUnpack(AFn^.Code[K].Imm, TargetIdx, FieldIdx);
+      if TargetIdx >= UInt32(Length(AIr.CanonTypes)) then
+        Continue;
+      CanonIdx := Integer(AIr.TypeIndexToCanon[TargetIdx]);
+      if (CanonIdx < 0) or (CanonIdx >= Length(AIr.CanonTypes)) then
+        Continue;
+      Comp := @AIr.CanonTypes[CanonIdx].Comp;
+      if (Comp^.Kind <> wckStruct) or
+        (FieldIdx >= UInt32(Length(Comp^.Struct.Fields))) then
+        Continue;
+      IsRef := False;
+      IsPacked := False;
+      PackedKind := wpkI8;
+      Width := 0;
+      Offset := 8;
+      for F := 0 to Integer(FieldIdx) do
+      begin
+        Width := StorageWidthOf(
+          Comp^.Struct.Fields[F].Storage);
+        Offset := (Offset + Width - 1) and not (Width - 1);
+        if F = Integer(FieldIdx) then
+        begin
+          IsRef := (not Comp^.Struct.Fields[F].Storage.IsPacked) and
+            (Comp^.Struct.Fields[F].Storage.ValueType.Kind = wvkRef);
+          IsPacked := Comp^.Struct.Fields[F].Storage.IsPacked;
+          PackedKind := Comp^.Struct.Fields[F].Storage.PackedType;
+        end
+        else
+          Offset := Offset + Width;
+      end;
+      if IsRef or (Width > 8) or (Offset >= $10000) or
+        ((Offset div Width) >= $1000) then
+        Continue;
+      case AFn^.Code[K].Op of
+        iroStructGet:
+          if IsPacked then
+            Continue;
+        iroStructGetS, iroStructGetU:
+          if not IsPacked then
+            Continue;
+      end;
+      { bit0 native | bit1 signed | bits8-15 width | bits16-31 offset }
+      GcShapes[K] := 1 or
+        (Ord(AFn^.Code[K].Op = iroStructGetS) shl 1) or
+        (UInt64(Width) shl 8) or
+        (UInt64(Offset) shl 16);
+    end;
+  end;
+
   procedure AnalyzePinnedMemory;
   var
     K: Integer;
@@ -1637,6 +1735,9 @@ begin
       host register their defining instruction would never have used. }
     AnalyzeConstSlots;
     {$IFDEF WASM_JIT_ARM64}
+    AnalyzeGcFieldAccess;
+    {$ENDIF}
+    {$IFDEF WASM_JIT_ARM64}
     AnalyzeDynamicWriteBack;
     {$ENDIF}
 
@@ -1767,7 +1868,8 @@ begin
             (AFn^.RegTypes[AFn^.Code[I].A].Num = wntI64),
             UsePinnedMemory, UsePinnedMemoryBase, UseExtendedFrame,
             UseNativeScalarCore, AFn^.RegisterCount, NativeParamReg,
-            NativeResultReg, NativeCoreLabel, NativeExhaustedLabel, ArmCache);
+            NativeResultReg, NativeCoreLabel, NativeExhaustedLabel, ArmCache,
+            @GcShapes[0]);
       end;
       {$ENDIF}
       {$IFDEF WASM_JIT_X64}

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -482,6 +482,8 @@ var
   MaskedShiftShape: array of UInt32;
   UseStaticCache: Boolean;
   UseThirdStatic: Boolean;
+  ConstSlots: array[0..0] of UInt32;
+  ConstSlotBits: array[0..0] of UInt64;
   UsePinnedMemory: Boolean;
   UsePinnedMemoryBase: Boolean;
   PinnedMemoryIndex: UInt32;
@@ -1361,6 +1363,130 @@ var
     UseStaticCache := True;
   end;
 
+  { Loop-invariant constants (loop limits, multipliers) sit inside the loop
+    body in IR order, so their materialization re-executes on every iteration.
+    A constant-defined slot with a dedicated static host register is seeded
+    once at frame entry instead; the defining const instruction then emits
+    nothing. Only slots written by exactly one const instruction qualify, and
+    never a slot the ordinary static allocation already claimed. }
+  procedure AnalyzeConstSlots;
+  type
+    TSpan = record
+      Lo: UInt32;
+      Hi: UInt32;
+    end;
+  var
+    K, M, Slot: Integer;
+    UniqueWriter: Boolean;
+    InLoop: Boolean;
+    ConstInLoop: array[0..0] of Boolean;
+    ConstLoopSpans: array of TSpan;
+
+    function SlotBeats(const AInLoop: Boolean; const AScore: UInt32;
+      const ABInLoop: Boolean; const ABScore: UInt32): Boolean;
+    begin
+      if AInLoop <> ABInLoop then
+        Result := AInLoop
+      else
+        Result := AScore > ABScore;
+    end;
+
+    function CoveredByLoop(const AIndex: UInt32): Boolean;
+    var
+      N: Integer;
+    begin
+      Result := False;
+      for N := 0 to High(ConstLoopSpans) do
+        if (ConstLoopSpans[N].Lo <= AIndex) and
+          (AIndex <= ConstLoopSpans[N].Hi) then
+          Exit(True);
+    end;
+
+    function AlreadyClaimed(const ASlot: UInt32): Boolean;
+    var
+      N: Integer;
+    begin
+      Result := True;
+      for N := 0 to High(ConstSlots) do
+        if ConstSlots[N] = ASlot then
+          Exit;
+      for N := 0 to High(AllocatedSlots) do
+        if AllocatedSlots[N] = ASlot then
+          Exit;
+      Result := False;
+    end;
+
+  procedure OfferConstSlot(const ASlot: UInt32; const ABits: UInt64;
+    const AInLoop: Boolean);
+    var
+      N: Integer;
+    begin
+      for N := 0 to High(ConstSlots) do
+      begin
+        if ConstSlots[N] = ASlot then
+          Exit;
+        if (ConstSlots[N] = High(UInt32)) or
+          SlotBeats(AInLoop, SlotScores[ASlot],
+          ConstInLoop[N], SlotScores[ConstSlots[N]]) then
+        begin
+          ConstSlots[N] := ASlot;
+          ConstSlotBits[N] := ABits;
+          ConstInLoop[N] := AInLoop;
+          Exit;
+        end;
+      end;
+    end;
+
+  begin
+    ConstSlots[0] := High(UInt32);
+    ConstInLoop[0] := False;
+    if not UseStaticCache or (Length(SlotScores) = 0) then
+      Exit;
+    { Loop spans from backward jumps: a constant defined between a back-edge
+      target and its jump re-materializes on every iteration, which is exactly
+      the cost a static host removes. Out-of-loop constants only save their
+      single emission, so they rank strictly below in-loop candidates. }
+    SetLength(ConstLoopSpans, 0);
+    for K := 0 to High(AFn^.Code) do
+      if (AFn^.Code[K].Op = iroJump) and
+        (AFn^.Code[K].A <= UInt32(K)) then
+      begin
+        SetLength(ConstLoopSpans, Length(ConstLoopSpans) + 1);
+        ConstLoopSpans[High(ConstLoopSpans)].Lo := AFn^.Code[K].A;
+        ConstLoopSpans[High(ConstLoopSpans)].Hi := UInt32(K);
+      end;
+    for K := 0 to High(AFn^.Code) do
+    begin
+      if not (AFn^.Code[K].Op in [iroI32Const, iroI64Const,
+        iroF32Const, iroF64Const]) then
+        Continue;
+      { A constant folded into a consumer never emits, so there is nothing
+        per-iteration to save. }
+      if SkipPlanned[K] then
+        Continue;
+      Slot := Integer(AFn^.Code[K].Dest);
+      if (Slot < 0) or (Slot >= Length(SlotScores)) then
+        Continue;
+      UniqueWriter := True;
+      for M := 0 to High(AFn^.Code) do
+        if (M <> K) and (AFn^.Code[M].Dest = AFn^.Code[K].Dest) then
+        begin
+          UniqueWriter := False;
+          Break;
+        end;
+      if not UniqueWriter or AlreadyClaimed(AFn^.Code[K].Dest) then
+        Continue;
+      InLoop := CoveredByLoop(UInt32(K));
+      case AFn^.Code[K].Op of
+        iroI32Const, iroF32Const:
+          OfferConstSlot(AFn^.Code[K].Dest,
+            UInt64(UInt32(AFn^.Code[K].Imm and $FFFFFFFF)), InLoop);
+        iroI64Const, iroF64Const:
+          OfferConstSlot(AFn^.Code[K].Dest, UInt64(AFn^.Code[K].Imm), InLoop);
+      end;
+    end;
+  end;
+
   procedure AnalyzePinnedMemory;
   var
     K: Integer;
@@ -1505,6 +1631,9 @@ begin
     {$ENDIF}
     AnalyzeImmediateFusion;
     AnalyzeFusion;
+    { After fusion planning, so already-folded constants are not offered a
+      host register their defining instruction would never have used. }
+    AnalyzeConstSlots;
     {$IFDEF WASM_JIT_ARM64}
     AnalyzeDynamicWriteBack;
     {$ENDIF}
@@ -1543,6 +1672,8 @@ begin
     if UseStaticCache then
     begin
       Arm64EnableStaticRegCache(Buf, ArmCache, AllocatedSlots);
+      if ConstSlots[0] <> High(UInt32) then
+        Arm64EnableConstSlots(Buf, ArmCache, ConstSlots, ConstSlotBits);
       if UsePinnedMemoryBase then
         Arm64EnableDynamicWriteBack(ArmCache, @SlotUseCounts[0],
           @VisibleSlots[0], AFn^.RegisterCount);

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -933,12 +933,14 @@ var
   begin
     {$IFDEF WASM_JIT_ARM64}
     { Validation lowers local.get to a move into a one-use expression slot.
-      In the helper-free base-pinned loop shape, forward that exact alias into
-      an already-cached consumer without changing the canonical IR or labels.
-      The four-instruction window covers the bounded lowering shapes while a
-      target, safepoint, or intervening write to the visible source ends the
-      proof. }
-    if not (UsePinnedMemoryBase and UseStaticCache) then
+      Forward that exact alias into an already-cached consumer without
+      changing the canonical IR or labels — in the helper-free base-pinned
+      loop shape, and in the closed native-scalar core whose parameters sit
+      in fixed hosts. The four-instruction window covers the bounded lowering
+      shapes while a target, safepoint, or intervening write to the visible
+      source ends the proof. }
+    if not ((UsePinnedMemoryBase and UseStaticCache) or
+        UseNativeScalarCore) then
       Exit;
     for K := 0 to High(PlannedCode) - 1 do
       if (PlannedCode[K].Op = iroMove) and not SkipPlanned[K] and

--- a/source/units/Wasm.Runtime.Gc.pas
+++ b/source/units/Wasm.Runtime.Gc.pas
@@ -535,6 +535,13 @@ type
       const AField: UInt32): Int32;
     function StructGetUnsigned(const ARef: TWasmRef;
       const AField: UInt32): UInt32;
+    { Writes fields 0..Count-1 from Values[0..Count-1] with a single layout
+      resolution — struct.new's shape, where per-field StructSet calls would
+      re-resolve the same layout N times. WriteField semantics per field are
+      unchanged; the v1 write barrier is empty (see its declaration), so a
+      sequential fill is observably identical to the per-field path. }
+    procedure StructSetSeq(const ARef: TWasmRef;
+      const AValues: PWasmValue; const ACount: UInt32);
     procedure StructSet(const ARef: TWasmRef; const AField: UInt32;
       const AValue: TWasmValue);
     { struct.get / struct.set on a v128 field (simd-spec §7). The field is
@@ -1671,6 +1678,24 @@ begin
     raise EWasmInternal.Create('internal: get_u on a field that is not packed');
   { Zero extension is what the narrow read already did. }
   Result := UInt32(ReadField(PByte(RefToPointer(ARef)), Field).Bits);
+end;
+
+procedure TWasmGcHeap.StructSetSeq(const ARef: TWasmRef;
+  const AValues: PWasmValue; const ACount: UInt32);
+var
+  Layout: PWasmGcLayout;
+  I: Integer;
+begin
+  if RefIsNull(ARef) then
+    TrapNow(wtkNullStructReference);
+  Layout := LayoutOf(ARef);
+  if Layout^.Kind <> wckStruct then
+    raise EWasmInternal.Create('internal: not a struct instance');
+  if UInt32(Length(Layout^.Fields)) < ACount then
+    raise EWasmInternal.Create('internal: struct field sequence overrun');
+  for I := 0 to Integer(ACount) - 1 do
+    WriteField(PByte(RefToPointer(ARef)), @Layout^.Fields[I],
+      PWasmValue(PByte(AValues) + NativeUInt(I) * SizeOf(TWasmValue))^);
 end;
 
 procedure TWasmGcHeap.StructSet(const ARef: TWasmRef; const AField: UInt32;


### PR DESCRIPTION
## Summary

Fourth-through-tenth waves of the benchmark-gated optimization series, executed under the optimize-runtime protocol (serialized same-load A/B, retained per-wave baseline binaries, guard workloads, tier-identity gates).

Accepted changes:
- **Loop-invariant constants seeded once in static-cache hosts** (`f191e18`): the driver picks a constant-defined slot (unique writer, inside a loop span, not fusion-eliminated); `Arm64EnableConstSlots` seeds its host register once at frame entry and the defining `const` emits nothing. Loop workload −3.8%/−3.8% both orders.
- **Native-core operand cleanup** (`6187bae`): AnalyzeLocalAliases extended to closed native-scalar cores (params already sit in fixed x12/x13 hosts) and cached constants materialize directly into their reserved victim. fib −10.3%/−8.2%, call −2.9%/−2.4%; leaf cores shrink 14 → 9 instructions.
- **Numeric struct field access natively on arm64** (`ec294dd`): driver-side AnalyzeGcFieldAccess mirrors TWasmGcTypes' layout math over CanonTypes and bakes offset/width/signedness; emitter does cached ref load, struct-specific null trap, width-sized access. Ref/v128 fields and oversized offsets decline to the helper. gc −24.8%/−25.2%.
- **struct.new fills resolve layout once** (`bbedb4a`): heap method StructSetSeq replaces N per-field StructSet crossings (each re-resolved the layout). gc −4.1%/−1.4%.

Rejected experiments with measured reasons are recorded in `.agent/HANDOFF.md`: K=2 const slots (memory-load +22/9%), SIMD v128 Q-hosts (+17–21% on their own target), loop-header alignment padding (no effect), GC layout memoization (noise), plus two standing measurement-hygiene rules (dev-vs-release builds; external VM load).

GC moves from ~3.6x to ~2.5x of Wasmtime on the gc workload; loop/fib/memory stay in or near parity.

## Testing

On the exact head: `lwpt install --frozen`, `lwpt format --check`, `lwpt agents --check`, Markdown lint (44 files, 0 issues), all 44 unit suites, and the pinned corpus byte-identical across interpreter/JIT/AOT at pass=65851 fail=368 skip=904 staged=0 errors=0 (compiled=8799). Serialized release-mode A/Bs for each accepted change used 7 samples per leg in BASE-CAND-CAND-BASE order under /tmp/wasmlight-perf-gate.lock with hash-retained predecessor binaries.

The Linux/x86-64 legs run in CI for this push; generated-code changes stay draft until those prove tier identity.

## Linked issues

None — this continues the optimization program tracked in `.agent/HANDOFF.md`.