### PR TITLE
perf(jit): inline the struct.new allocation fast path on arm64

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,13 +1,28 @@
 # Handoff
 
-Updated: 2026-08-23 (wave 11 executed: inline struct.new fast path ACCEPTED)
+Updated: 2026-08-23 (PR #19 CI repair validated locally)
+
+## PR #19 CI repair
+
+- Exact failing head `eac9dbe`: Linux/x86-64 and runtime-comparison builds
+  could not resolve the arm64-only `TWasmGcAllocShape` / `TWasmGcAllocInfo`
+  types because their driver variables and analyzer were backend-shared.
+- Repair: compile those declarations and the analyzer only under
+  `WASM_JIT_ARM64`; keep exact-size eligibility aligned with the PR claim
+  (`CellSize == Size`); remove the temporary `WASMLIGHT_DUMP_FASTPATH`
+  emitter output.
+- Current local evidence: macOS/arm64 focused JIT + emitter suites pass;
+  Ubuntu Noble/x86-64 release builds all three programs and passes the JIT +
+  X64 suites; the universal macOS gate passes frozen install, format, all
+  three builds, all 44 test programs, `lwpt agents --check`, and diff check.
+- Delivery stays on draft PR #19. Re-query its exact head and checks rather
+  than relying on this handoff for live CI state.
 
 ## Wave 11 — inline struct.new allocation fast path ACCEPTED
 
 - Commit `6aea5ef` (`perf(jit): inline the struct.new allocation fast path
   on arm64`) on `t3code/optimize-runtime-wasmtime-gap-2` from exact
-  `12c41b7` (the post-PR-18 main tip). Local, unpushed; delivery not
-  requested.
+  `12c41b7` (the post-PR-18 main tip). Published through draft PR #19.
 - Mechanism per the wave-11 design: eligible `struct.new` sites emit the
   whole free-list-hit allocation inline — context-chain engine-id walk,
   heap/head load, cbz miss branch into the UNCHANGED generic emission (still

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,8 +1,66 @@
 # Handoff
 
-Updated: 2026-08-22 (wave 11 scoping: inline-alloc design RESOLVED, not built)
+Updated: 2026-08-23 (wave 11 executed: inline struct.new fast path ACCEPTED)
 
-## Wave 11 — inline struct.new allocation: design finalized, execution deferred
+## Wave 11 — inline struct.new allocation fast path ACCEPTED
+
+- Commit `6aea5ef` (`perf(jit): inline the struct.new allocation fast path
+  on arm64`) on `t3code/optimize-runtime-wasmtime-gap-2` from exact
+  `12c41b7` (the post-PR-18 main tip). Local, unpushed; delivery not
+  requested.
+- Mechanism per the wave-11 design: eligible `struct.new` sites emit the
+  whole free-list-hit allocation inline — context-chain engine-id walk,
+  heap/head load, cbz miss branch into the UNCHANGED generic emission (still
+  THE collect safepoint per ADR-0011), pop, bitmap mark, counters ×3,
+  two-half header, baked numeric field stores, Dest publish last. Driver
+  analysis mirrors Allocate's class math exactly; pow2 classes only
+  (16/32/64/128/256 — where CellSize == AlignUp(layoutSize,8), so the tail
+  is zero by construction and no inline zeroing is needed); declines ref/v128
+  fields, struct.new_default, arity > 16, non-pow2/large cells, offsets out
+  of imm12 range. New probes (WasmJitGcHeapOffsets, WasmJitStoreAllocOffsets)
+  expose the private anchors; ALL folded into the ABI fingerprint, revision
+  15 (old artifacts fail closed).
+- TWO emitter defects found and fixed inside the wave:
+  1. Arm64MaddX used the $8B (ADD/W-MADD) base instead of $9B — the walk
+     computed a garbage activation address; found by bisect + llvm-mc
+     cross-check of the pinned words.
+  2. The header stores preceded the link pop, overwriting [head+0] before
+     the link was read — the free list was poisoned with mark-state values
+     and the NEXT fast-path allocation jumped to garbage. Found only when a
+     workload actually recycles cells (runtime-comparison gc module under
+     --aot); the corpus never fires the fast path (tiny heaps, empty lists),
+     which is why three-tier corpus identity alone did not catch it. The
+     reuse test now covers this shape.
+- Serialized release A/B under the perf gate (bench.py best profile, 1
+  warmup discarded, 7 samples, BASE-CAND-CAND-BASE): gc **−39.9%/−39.9%**
+  (76.209/76.511 → 45.780/45.773 ms; spreads disjoint: base 75.86–85.51,
+  cand 45.34–46.16). Guards flat within this host's documented noise:
+  fib/call/host-call/simd/startup deltas < ±2%; loop and memory-* legs
+  drifted across LATER legs on BOTH binaries (base2 measured loop 362.9 ≈
+  cand's 363.0), so those swings are host drift, not candidate effects —
+  no guard regressed in like-for-like order pairs.
+- Band status vs same-schedule Wasmtime-AOT medians: IN BAND startup 0.67x,
+  host-call 0.90x, fib 0.93x, memory-grow 0.89x, loop 1.06x, memory 1.13x,
+  memory-load 1.19x; BORDERLINE memory-store 1.45x; OUT OF BAND gc **1.61x**
+  (was ~2.5x), call 2.30x, simd 1.82x. Goal remains every workload ≤ 1.43x.
+- Correctness on the accepted head (release `8613383e…`): 44/44 unit suites;
+  corpus byte-identical in interpreter/JIT/AOT at pass=65851 fail=368
+  skip=904 staged=0 errors=0 (compiled=8799); format, agents check, frozen
+  install, diff-check, Markdown lint green. New tests: differential
+  recycled-cell reuse under threshold-0 forced collects (both tiers agree)
+  and a 43-word pin of the emitted fast-path sequence.
+- PROCESS NOTE: dev and release builds have DIFFERENT object layouts
+  (test-only fields under {$IFNDEF PRODUCTION}); probes are self-consistent
+  per build and the fingerprint keeps artifacts from crossing builds — do
+  not compare dev-baked offsets against release runs.
+- Next lanes in priority order: (1) native array.get/set with baked element
+  offsets + bounds check (remaining gc-workload crossings + runtime IrAux
+  reads); (2) hoist per-call target/cap resolution across backedges for
+  proof-gated direct calls (call lane, ~22 instructions around each blr);
+  (3) simd microarchitectural bisect (wave 7 ruled out alignment);
+  (4) x64 mirrors of the arm64 GC lanes.
+
+## Wave 11 design record — superseded by the execution above
 
 - Scoping pass produced every remaining design answer; implementation did
   not start (GC-critical surface + late-session budget). Build order for the

--- a/source/units/Wasm.Interp.pas
+++ b/source/units/Wasm.Interp.pas
@@ -337,7 +337,10 @@ const
     template's byte layout, a pinned-register reassignment, the entry-ABI shape.
     Bump it whenever position-independent codegen changes in a way that would
     make an existing artifact's bytes wrong. }
-  AOT_ABI_REVISION = 14;
+  { Revision 15: the wave-11 inline struct.new fast path bakes the GC-heap,
+    block, and instance engine-id offsets; artifacts from revision 14 carry
+    no such loads but fail closed against a runtime that could emit them. }
+  AOT_ABI_REVISION = 15;
 
 { A deterministic 64-bit fingerprint over everything a serialized artifact's
   code bakes as a constant and the loading runtime must therefore agree on
@@ -3459,6 +3462,7 @@ var
   H: UInt64;
   JO: TWasmJitOffsets;
   FO: TWasmJitFrameOffsets;
+  GO: TWasmJitGcOffsets;
 
   { FNV-1a-64 fold of one 64-bit datum: enough to make an accidental ABI drift
     change the fingerprint deterministically (this is an identity guard, not a
@@ -3505,6 +3509,19 @@ begin
   Fold(JO.MemInstStride);
   Fold(JO.MemBase);
   Fold(JO.MemByteSize);
+  Fold(JO.StoreFHeap);
+  Fold(JO.StoreTierContext);
+  Fold(JO.InstEngineTypeIds);
+
+  { The inline-allocation fast path bakes heap/block offsets too (wave 11). }
+  GO := WasmJitGcHeapOffsets;
+  Fold(GO.HeapFFree0);
+  Fold(GO.HeapMarkState);
+  Fold(GO.HeapBytesLive);
+  Fold(GO.HeapBytesAllocated);
+  Fold(GO.HeapObjectCount);
+  Fold(GO.BlockBase);
+  Fold(GO.BlockAllocated);
 
   Fold(FO.ValueSlotSize);
   Fold(FO.CtxValues);

--- a/source/units/Wasm.Jit.Arm64.Test.pas
+++ b/source/units/Wasm.Jit.Arm64.Test.pas
@@ -73,6 +73,7 @@ type
     procedure TestExecSubTemplate;
     procedure TestExecShlMasksCount;
     procedure TestExecRelopSigned;
+    procedure TestInlineStructNewFastPathWords;
     procedure TestExecConst;
     procedure TestExecI64Add;
   end;
@@ -389,7 +390,8 @@ begin
     Arm64InitRegCache(Cache);
     Expect<Boolean>(Arm64EmitOpCached(Buf,
       MakeIrInstr(iroI32Const, 0, 0, 0, 7), Aux,
-      0, False, False, False, False, True, 1, 0, 0, 0, 0, Cache)).ToBe(True);
+      0, False, False, False, False, True, 1, 0, 0, 0, 0, Cache,
+      nil, nil, Default(TWasmGcAllocInfo))).ToBe(True);
     Expect<Boolean>(Buf.Size > 0).ToBe(True);
   finally
     Buf.Free;
@@ -806,6 +808,76 @@ begin
   {$ENDIF}
 end;
 
+const
+  { Wave 11 -- the inline struct.new fast path pinned word for word for the
+    canonical shape of one i32 field at cell offset 8, class-16 cell, engine
+    id loaded through the context chain. Offsets are the dev-build probe
+    values; emitter drift, encoder typos, or offset changes fail here first. }
+  FastPathWords: array[0 .. 42] of UInt32 = (
+    $F9405689, $F9401D2C, $D100058C, $F940152A,             { ctx walk }
+    $52800F09, $9B09298C, $F940058C, $F9402D8C, $B9400189,
+    $F9400E8A,                                             { store -> heap }
+    $F940194B,                                             { FFree[0] head }
+    $3400040B,                                             { cbz head -> slow }
+    $F940016C, $F900194C,                                  { pop link FIRST }
+    $B9000569,                                             { hdr hi = typeId }
+    $F9408549, $B9000169,                                  { hdr lo = mark }
+    $F9400569, $F940052A, $CB0A016A,                       { block, base, diff }
+    $53047D4A,                                             { lsr w10,#4 cell }
+    $F9401129,                                             { alloc bitmap ptr }
+    $53057D4C, $1200794D, $5280002A, $1ACD214A,            { word idx, mask }
+    $B86C692D, $2A0A01AD, $B82C692D,                       { word |= mask }
+    $F9400E89, $F9408D2A, $9100414A, $F9008D2A,            { BytesLive += 16 }
+    $F940912A, $9100414A, $F900912A,                       { BytesAllocated }
+    $F9409D2A, $9100054A, $F9009D2A,                       { ObjectCount += 1 }
+    $F9400A6C, $B900096C,                                  { field i32 @8 }
+    $F9000E6B,                                             { publish Dest }
+    $14000001);                                            { b Done }
+
+procedure TArm64Tests.TestInlineStructNewFastPathWords;
+var
+  Buf: TWasmCodeBuffer;
+  Cache: TArm64RegCache;
+  Ins: TWasmIrInstr;
+  Shape: TWasmGcAllocShape;
+  Info: TWasmGcAllocInfo;
+  SlowLbl, DoneLbl: TWasmJitLabel;
+  I: Integer;
+  W: UInt32;
+  Words: TWasmBytes;
+begin
+  Buf := TWasmCodeBuffer.Create;
+  try
+    Arm64InitRegCache(Cache);
+    FillChar(Shape, SizeOf(Shape), 0);
+    Shape.Word := 1 or (UInt64(1) shl 8) or (UInt64(4) shl 16);
+    Shape.Fields[0].Slot := 2;
+    Shape.Fields[0].Offset := 8;
+    Shape.Fields[0].Width := 4;
+    Info.FHeapOffset := 24;
+    Info.TierContextOffset := 168;
+    Info.EngineTypeIdsOffset := 88;
+    Ins := MakeIrInstr(iroStructNew, 3, 0, 0, 0);
+    Arm64EmitInlineStructNew(Buf, Ins, Shape, Info, Cache, SlowLbl, DoneLbl);
+    Buf.BindLabel(SlowLbl);
+    Buf.BindLabel(DoneLbl);
+    Arm64ResolvePatches(Buf);
+    Words := Buf.SnapshotBytes;
+    Expect<NativeUInt>(NativeUInt(Length(Words)) div 4)
+      .ToBe(NativeUInt(Length(FastPathWords)));
+    W := 0;
+    for I := 0 to High(FastPathWords) do
+    begin
+      Move(Words[I * 4], W, 4);
+      if (W <> FastPathWords[I]) and (I < High(FastPathWords)) then
+        Break;
+    end;
+    Expect<UInt32>(W).ToBe(FastPathWords[High(FastPathWords)]);
+  finally
+    Buf.Free;
+  end;
+end;
+
 procedure TArm64Tests.TestExecRelopSigned;
 {$IF DEFINED(WASM_JIT_EXEC) AND DEFINED(CPUAARCH64)}
 var
@@ -922,6 +994,7 @@ begin
   Test('executes the move template as a full slot copy', TestExecMoveTemplate);
   Test('executes the i32.sub template', TestExecSubTemplate);
   Test('i32.shl masks the shift count modulo 32', TestExecShlMasksCount);
+  Test('inline struct.new fast path emits the pinned words', TestInlineStructNewFastPathWords);
   Test('executes a signed i32 relop via cmp+cset', TestExecRelopSigned);
   Test('executes an i32.const template', TestExecConst);
   Test('executes a full-width i64.add template', TestExecI64Add);

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -112,6 +112,38 @@ type
   TArm64GcShapeArray = array[0..$FFFFFF] of UInt64;
   PArm64GcShapeArray = ^TArm64GcShapeArray;
 
+  { One baked numeric field of a wave-11 inline struct.new: the source
+    register slot, the cell byte offset, and the truncating store width —
+    the same three numbers TWasmGcHeap's WriteField would have resolved at
+    run time. }
+  TWasmGcAllocField = record
+    Slot: UInt32;
+    Offset: UInt32;
+    Width: Byte;
+  end;
+
+  { Per-instruction shape for the inline-allocation fast path. Word bit0
+    enables; bits8-15 hold the field count, bits16-23 log2(CellSize) of the
+    power-of-two size class. The engine type id is deliberately NOT here —
+    it is per-store runtime state, loaded through the context chain so AOT
+    artifacts stay instance/store-agnostic. }
+  TWasmGcAllocShape = record
+    Word: UInt64;
+    Fields: array[0..15] of TWasmGcAllocField;
+  end;
+
+  TArm64GcAllocArray = array[0..$FFFFFF] of TWasmGcAllocShape;
+  PArm64GcAllocArray = ^TArm64GcAllocArray;
+
+  { The store-relative offsets the fast path cannot probe itself (FHeap is
+    private to Wasm.Runtime.Store); computed once per staged function from
+    WasmJitOffsets and threaded beside the shape array. }
+  TWasmGcAllocInfo = record
+    FHeapOffset: NativeUInt;
+    TierContextOffset: NativeUInt;
+    EngineTypeIdsOffset: NativeUInt;
+  end;
+
   PArm64RegCache = ^TArm64RegCache;
 
   TArm64RegCacheEntry = record
@@ -241,6 +273,7 @@ function Arm64SubW(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64SubX(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64MulW(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64MulX(const ARd, ARn, ARm: Byte): UInt32;
+function Arm64MaddX(const ARd, ARn, ARm, ARa: Byte): UInt32;
 function Arm64SdivW(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64SdivX(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64UdivW(const ARd, ARn, ARm: Byte): UInt32;
@@ -250,6 +283,7 @@ function Arm64MsubX(const ARd, ARn, ARm, ARa: Byte): UInt32;
 function Arm64AndW(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64AndLowMaskImmW(const ARd, ARn, AOnes: Byte): UInt32;
 function Arm64LslImmW(const ARd, ARn, AShift: Byte): UInt32;
+function Arm64LsrImmW(const ARd, ARn, AShift: Byte): UInt32;
 function Arm64AddImmW(const ARd, ARn: Byte; const AImm12: UInt32): UInt32;
 function Arm64AndX(const ARd, ARn, ARm: Byte): UInt32;
 function Arm64OrrW(const ARd, ARn, ARm: Byte): UInt32;
@@ -548,13 +582,24 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
   const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
   var ACache: TArm64RegCache;
-  const AGcShapes: PArm64GcShapeArray = nil): Boolean; overload;
+  const AGcShapes: PArm64GcShapeArray;
+  const AGcAlloc: PArm64GcAllocArray;
+  const AGcAllocInfo: TWasmGcAllocInfo): Boolean; overload;
 { Numeric struct field access with a baked byte offset — the layout math is
   mirrored in the driver's AnalyzeGcFieldAccess, so no runtime resolution
   remains. Null refs trap the struct-specific kind before any load. }
 procedure Arm64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AShape: UInt64;
   var ACache: TArm64RegCache);
+{ Wave 11 — the inline struct.new fast path. Emits the free-list-hit
+  allocation straight line (pop, bitmap, counters, header, baked numeric
+  fields) and jumps to ADoneLabel; the caller binds its slow label at the
+  unchanged generic (helper) emission so a miss or an exhausted class falls
+  back to exactly the code that ran before. }
+procedure Arm64EmitInlineStructNew(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AShape: TWasmGcAllocShape;
+  const AInfo: TWasmGcAllocInfo; var ACache: TArm64RegCache;
+  out ASlowLabel, ADoneLabel: TWasmJitLabel);
 function Arm64CanUseI32Immediate(const AOp: TWasmIrOp;
   const AValue: UInt32): Boolean;
 function Arm64EmitOpCachedImmediate(const ABuf: TWasmCodeBuffer;
@@ -625,6 +670,8 @@ function Arm64CachedDestReg(const ABuf: TWasmCodeBuffer;
 procedure EmitCbnzTo(const ABuf: TWasmCodeBuffer; const ARt: Byte;
   const ATarget: UInt32); forward;
 procedure EmitCbzTo(const ABuf: TWasmCodeBuffer; const ARt: Byte;
+  const ATarget: UInt32); forward;
+procedure EmitBranchTo(const ABuf: TWasmCodeBuffer;
   const ATarget: UInt32); forward;
 procedure EmitNativeScalarSelfCallReg(const ABuf: TWasmCodeBuffer;
   const ARegisterCount: UInt32;
@@ -959,7 +1006,7 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
 begin
   Result := Arm64EmitOpCached(ABuf, AIns, AAux, AInsIndex, AAddr64,
     AUsePinnedMemory, AUsePinnedMemoryBase, AExtendedFrame, False, 0, 0, 0,
-    0, 0, ACache, nil);
+    0, 0, ACache, nil, nil, Default(TWasmGcAllocInfo));
 end;
 
 procedure Arm64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
@@ -1035,6 +1082,149 @@ begin
   end;
 end;
 
+procedure Arm64EmitInlineStructNew(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AShape: TWasmGcAllocShape;
+  const AInfo: TWasmGcAllocInfo; var ACache: TArm64RegCache;
+  out ASlowLabel, ADoneLabel: TWasmJitLabel);
+const
+  { Two scratches beyond the named three. The caller has flushed and
+    invalidated the value cache before this template runs, and a function
+    containing an allocation is never static-cache eligible (iroStructNew
+    fails StaticCacheOp), so the write-through hosts are dead metadata here. }
+  R3 = ARM64_REG_CACHE0;   { x12 }
+  R4 = ARM64_REG_CACHE1;   { x13 }
+var
+  GO: TWasmJitGcOffsets;
+  FO: TWasmJitFrameOffsets;
+  Count, Log2Cell, F: Integer;
+  FreeOff: UInt32;
+begin
+  GO := WasmJitGcHeapOffsets;
+  FO := WasmJitFrameOffsets;
+  if GetEnvironmentVariable('WASMLIGHT_DUMP_FASTPATH') <> '' then
+    WriteLn('TEMP-EMIT tierctx=', AInfo.TierContextOffset,
+      ' fheap=', AInfo.FHeapOffset, ' etids=', AInfo.EngineTypeIdsOffset,
+      ' depth=', FO.CtxDepth, ' acts=', FO.CtxActs, ' stride=', FO.ActStride,
+      ' actinst=', FO.ActInstance, ' ffree0=', GO.HeapFFree0,
+      ' mark=', GO.HeapMarkState, ' blkbase=', GO.BlockBase,
+      ' blkalloc=', GO.BlockAllocated, ' blive=', GO.HeapBytesLive,
+      ' balloc=', GO.HeapBytesAllocated, ' objs=', GO.HeapObjectCount);
+  Count := Integer((AShape.Word shr 8) and $FF);
+  Log2Cell := Integer((AShape.Word shr 16) and $FF);
+  FreeOff := UInt32(GO.HeapFFree0) +
+    UInt32((AShape.Word shr 24) and $FF) * 8;
+  ASlowLabel := ABuf.NewLabel;
+  ADoneLabel := ABuf.NewLabel;
+
+  { The engine type id is per-store runtime state: walk the context chain to
+    THIS activation's instance (the walk is call-safe — an activation's
+    Instance field is fixed for its lifetime) and load EngineTypeIds[Imm].
+    wokStruct is ordinal 0, so a struct header's kind bits are zero and the
+    whole word is markState | typeId shl 32, written as two halves. }
+  Arm64EmitLdrX(ABuf, ARM64_REG_T0, ARM64_REG_STORE,
+    UInt32(AInfo.TierContextOffset));
+  Arm64EmitLdrX(ABuf, R3, ARM64_REG_T0, UInt32(FO.CtxDepth));
+  ABuf.EmitU32(Arm64SubImmX(R3, R3, 1));
+  Arm64EmitLdrX(ABuf, ARM64_REG_T1, ARM64_REG_T0, UInt32(FO.CtxActs));
+  ABuf.EmitU32(Arm64MovzW(ARM64_REG_T0, UInt16(FO.ActStride), 0));
+  ABuf.EmitU32(Arm64MaddX(R3, R3, ARM64_REG_T0, ARM64_REG_T1));
+  Arm64EmitLdrX(ABuf, R3, R3, UInt32(FO.ActInstance));
+  Arm64EmitLdrX(ABuf, R3, R3, UInt32(AInfo.EngineTypeIdsOffset));
+  Arm64EmitLdrW(ABuf, ARM64_REG_T0, R3, UInt32(AIns.Imm) * 4);
+
+  { Free-list head for this size class; a miss falls to the unchanged
+    helper path, which stays THE collect safepoint (ADR-0011). }
+  Arm64EmitLdrX(ABuf, ARM64_REG_T1, ARM64_REG_STORE,
+    UInt32(AInfo.FHeapOffset));
+  Arm64EmitLdrX(ABuf, ARM64_REG_T2, ARM64_REG_T1, FreeOff);
+  EmitCbzTo(ABuf, ARM64_REG_T2, UInt32(ASlowLabel));
+
+  { Pop FIRST: FFree[class] := [head + LINK]. The link word shares its qword
+    with the header low half this very sequence is about to write, so the
+    header stores MUST NOT precede it — and the pop parks the new head in R3,
+    leaving T0's parked type id alone. }
+  Arm64EmitLdrX(ABuf, R3, ARM64_REG_T2,
+    WASM_GC_FREE_LINK_OFFSET);
+  Arm64EmitStrX(ABuf, R3, ARM64_REG_T1, FreeOff);
+
+  { Header high half — consumes the parked type id. }
+  Arm64EmitStrW(ABuf, ARM64_REG_T0, ARM64_REG_T2, 4);
+
+  { Header low half = mark state; the next cycle's polarity flip (H8)
+    unmarks exactly like an Allocate-written header. }
+  Arm64EmitLdrX(ABuf, ARM64_REG_T0, ARM64_REG_T1,
+    UInt32(GO.HeapMarkState));
+  Arm64EmitStrW(ABuf, ARM64_REG_T0, ARM64_REG_T2, 0);
+
+  { Bitmap: word = Allocated[(head-Base)/CellSize div 32] |=
+    1 shl (... mod 32). CellSize is a power-of-two class size, so the
+    division is one shift and the cell index needs no magic multiply. }
+  Arm64EmitLdrX(ABuf, ARM64_REG_T0, ARM64_REG_T2,
+    WASM_GC_FREE_BLOCK_OFFSET);
+  Arm64EmitLdrX(ABuf, ARM64_REG_T1, ARM64_REG_T0, UInt32(GO.BlockBase));
+  ABuf.EmitU32(Arm64SubX(ARM64_REG_T1, ARM64_REG_T2, ARM64_REG_T1));
+  ABuf.EmitU32(Arm64LsrImmW(ARM64_REG_T1, ARM64_REG_T1, Byte(Log2Cell)));
+  Arm64EmitLdrX(ABuf, ARM64_REG_T0, ARM64_REG_T0,
+    UInt32(GO.BlockAllocated));
+  ABuf.EmitU32(Arm64LsrImmW(R3, ARM64_REG_T1, 5));            { word idx }
+  ABuf.EmitU32(Arm64AndLowMaskImmW(R4, ARM64_REG_T1, 31));    { bit no }
+  ABuf.EmitU32(Arm64MovzW(ARM64_REG_T1, 1, 0));
+  ABuf.EmitU32(Arm64LslvW(ARM64_REG_T1, ARM64_REG_T1, R4));   { mask }
+  ABuf.EmitU32(Arm64MemRegOffset($B9400000, R4, ARM64_REG_T0, R3, True));
+  ABuf.EmitU32(Arm64OrrW(R4, R4, ARM64_REG_T1));
+  ABuf.EmitU32(Arm64MemRegOffset($B9000000, R4, ARM64_REG_T0, R3, True));
+
+  { Host-visible counters. Each reloads the heap base — the pop above
+    consumed the only copy — because three live base pointers do not fit
+    the scratch set and one LDR is cheaper than a fourth register would be.
+    CellSize == the class size == 2^Log2Cell exactly on this path. }
+  Arm64EmitLdrX(ABuf, ARM64_REG_T0, ARM64_REG_STORE,
+    UInt32(AInfo.FHeapOffset));
+  Arm64EmitLdrX(ABuf, ARM64_REG_T1, ARM64_REG_T0,
+    UInt32(GO.HeapBytesLive));
+  ABuf.EmitU32(Arm64AddImmX(ARM64_REG_T1, ARM64_REG_T1,
+    UInt32(1) shl Log2Cell));
+  Arm64EmitStrX(ABuf, ARM64_REG_T1, ARM64_REG_T0,
+    UInt32(GO.HeapBytesLive));
+  Arm64EmitLdrX(ABuf, ARM64_REG_T1, ARM64_REG_T0,
+    UInt32(GO.HeapBytesAllocated));
+  ABuf.EmitU32(Arm64AddImmX(ARM64_REG_T1, ARM64_REG_T1,
+    UInt32(1) shl Log2Cell));
+  Arm64EmitStrX(ABuf, ARM64_REG_T1, ARM64_REG_T0,
+    UInt32(GO.HeapBytesAllocated));
+  Arm64EmitLdrX(ABuf, ARM64_REG_T1, ARM64_REG_T0,
+    UInt32(GO.HeapObjectCount));
+  ABuf.EmitU32(Arm64AddImmX(ARM64_REG_T1, ARM64_REG_T1, 1));
+  Arm64EmitStrX(ABuf, ARM64_REG_T1, ARM64_REG_T0,
+    UInt32(GO.HeapObjectCount));
+
+  { Numeric field fills at baked offsets, sources straight from the
+    canonical register file (the cache was invalidated on entry). }
+  for F := 0 to Count - 1 do
+  begin
+    Arm64EmitLdrX(ABuf, R3, ARM64_REG_REGFILE,
+      Arm64SlotByteOffset(AShape.Fields[F].Slot));
+    case AShape.Fields[F].Width of
+      1: ABuf.EmitU32($39000000 or AShape.Fields[F].Offset or
+           (UInt32(ARM64_REG_T2) shl 5) or R3);
+      2: ABuf.EmitU32($79000000 or ((UInt32(AShape.Fields[F].Offset)
+           div 2) shl 10) or (UInt32(ARM64_REG_T2) shl 5) or R3);
+      4: ABuf.EmitU32($B9000000 or ((UInt32(AShape.Fields[F].Offset)
+           div 4) shl 10) or (UInt32(ARM64_REG_T2) shl 5) or R3);
+    else
+      ABuf.EmitU32($F9000000 or ((UInt32(AShape.Fields[F].Offset)
+        div 8) shl 10) or (UInt32(ARM64_REG_T2) shl 5) or R3);
+    end;
+  end;
+
+  { Publish the reference last. Nothing between the header store and here
+    can collect — the fast path contains no safepoint — so publish-first's
+    ordering obligation is met trivially, and a source slot that equals
+    Dest was read before this overwrite. }
+  StX(ABuf, ARM64_REG_T2, AIns.Dest);
+  EmitBranchTo(ABuf, UInt32(ADoneLabel));
+end;
+
 function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
   const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory,
@@ -1042,11 +1232,14 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
   const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
   var ACache: TArm64RegCache;
-  const AGcShapes: PArm64GcShapeArray): Boolean; overload;
+  const AGcShapes: PArm64GcShapeArray;
+  const AGcAlloc: PArm64GcAllocArray;
+  const AGcAllocInfo: TWasmGcAllocInfo): Boolean; overload;
 var
   Source, Dest: Byte;
   ArgSlot, ResultSlot: UInt32;
   ConstHost: Byte;
+  SlowLabel, DoneLabel: TWasmJitLabel;
 begin
   Result := True;
   if Arm64ScalarMemoryOp(AIns.Op) then
@@ -1225,6 +1418,25 @@ begin
       ((AGcShapes[AInsIndex] and 1) <> 0) then
     begin
       Arm64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
+      Exit;
+    end;
+    { Wave 11: an eligible struct.new takes the inline free-list fast path;
+      its miss branch lands on the unchanged generic (helper) emission below,
+      so the slow path is byte-for-byte what this op emitted before. }
+    if (AGcAlloc <> nil) and (AIns.Op = iroStructNew) and
+      ((AGcAlloc[AInsIndex].Word and 1) <> 0) then
+    begin
+      Arm64FlushDynamicRegCache(ABuf, ACache);
+      Arm64InvalidateRegCache(ACache);
+      DoneLabel := 0;
+      Arm64EmitInlineStructNew(ABuf, AIns, AGcAlloc[AInsIndex],
+        AGcAllocInfo, ACache, SlowLabel, DoneLabel);
+      ABuf.BindLabel(SlowLabel);
+      Arm64InvalidateRegCache(ACache);
+      Result := Arm64EmitOp(ABuf, AIns, AAux, AInsIndex, AUsePinnedMemory,
+        ANativeScalarSelf, ANativeRegisterCount, ANativeParamReg,
+        ANativeResultReg, ANativeCoreLabel, ANativeExhaustedLabel);
+      ABuf.BindLabel(DoneLabel);
       Exit;
     end;
     { Helpers, safepoints, complex control and currently uncached templates all
@@ -2479,6 +2691,15 @@ begin
   Result := $9B007C00 or (UInt32(ARm) shl 16) or (UInt32(ARn) shl 5) or ARd;
 end;
 
+function Arm64MaddX(const ARd, ARn, ARm, ARa: Byte): UInt32;
+begin
+  { MADD Xd,Xn,Xm,Xa — the general three-operand form Arm64MulX specializes.
+    The X-form base is $9B (bit31 sf=1 above the $1B W-form); $8B would be a
+    plain shifted-register ADD. }
+  Result := $9B000000 or (UInt32(ARm) shl 16) or (UInt32(ARa) shl 10) or
+    (UInt32(ARn) shl 5) or ARd;
+end;
+
 function Arm64SdivW(const ARd, ARn, ARm: Byte): UInt32;
 begin
   Result := $1AC00C00 or (UInt32(ARm) shl 16) or (UInt32(ARn) shl 5) or ARd;
@@ -2529,6 +2750,13 @@ begin
   Shift := AShift and 31;
   Result := $53000000 or (UInt32((32 - Shift) and 31) shl 16) or
     (UInt32(31 - Shift) shl 10) or (UInt32(ARn) shl 5) or ARd;
+end;
+
+function Arm64LsrImmW(const ARd, ARn, AShift: Byte): UInt32;
+begin
+  { LSR Wd,Wn,#s = UBFM Wd,Wn,#s,#31. }
+  Result := $53000000 or (UInt32(AShift and 31) shl 16) or
+    (UInt32(31) shl 10) or (UInt32(ARn) shl 5) or ARd;
 end;
 
 function Arm64AddImmW(const ARd, ARn: Byte;

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -1101,14 +1101,6 @@ var
 begin
   GO := WasmJitGcHeapOffsets;
   FO := WasmJitFrameOffsets;
-  if GetEnvironmentVariable('WASMLIGHT_DUMP_FASTPATH') <> '' then
-    WriteLn('TEMP-EMIT tierctx=', AInfo.TierContextOffset,
-      ' fheap=', AInfo.FHeapOffset, ' etids=', AInfo.EngineTypeIdsOffset,
-      ' depth=', FO.CtxDepth, ' acts=', FO.CtxActs, ' stride=', FO.ActStride,
-      ' actinst=', FO.ActInstance, ' ffree0=', GO.HeapFFree0,
-      ' mark=', GO.HeapMarkState, ' blkbase=', GO.BlockBase,
-      ' blkalloc=', GO.BlockAllocated, ' blive=', GO.HeapBytesLive,
-      ' balloc=', GO.HeapBytesAllocated, ' objs=', GO.HeapObjectCount);
   Count := Integer((AShape.Word shr 8) and $FF);
   Log2Cell := Integer((AShape.Word shr 16) and $FF);
   FreeOff := UInt32(GO.HeapFFree0) +

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -970,6 +970,37 @@ begin
   ]);
 end;
 
+{ Wave 11 differential: ONE struct type, and a body that drops a live struct
+  and allocates again. With Threshold=0 (set by the test) the second
+  struct.new collects first, sweeps the dropped cell onto its free list, and
+  the compiled fast path pops that RECYCLED cell — stale header, poison bytes
+  in padding and all — then writes its own header and field. Both tiers must
+  observe the identical fresh value, which is only possible if every byte any
+  instruction can name is rewritten by the fast path. }
+function GcReuseModuleBytes: TWasmBytes;
+begin
+  Result := Cat([
+    BLit(WASM_HEADER),
+    Sect(1, VecOf([
+      BLit([$5F, $01, $7F, $01]),                    { 0: struct (mut i32) }
+      BLit([$60, $01, $7F, $01, $7F])])),            { 1: (i32)->i32 }
+    Sect(3, VecOf([BLit([$01])])),
+    Sect(7, VecOf([ExportEntry('reuse', $00, 0)])),
+    Sect(10, VecOf([
+      CodeEntry([$01, $01, $63, $00,                  { local (ref null 0) }
+        $20, $00,                                     { local.get 0 }
+        $FB, $00, $00,                                { struct.new 0 -> A }
+        $21, $01,                                     { local.set 1 }
+        $D0, $00,                                     { ref.null 0 }
+        $21, $01,                                     { drop A }
+        $20, $00, $41, $01, $6A,                      { arg + 1 }
+        $FB, $00, $00,                                { struct.new 0 -> B recycles A }
+        $21, $01,
+        $20, $01,                                     { local.get 1 }
+        $FB, $02, $00, $00,                           { struct.get 0 0 }
+        $0B])]))]);
+end;
+
 { GC arrays. type 0 = array (mut i32); type 1 = array (mut i8) packed. Round-
   trip, length, packed sign/zero get, and an out-of-bounds get (a 'out of
   bounds array access' trap). }
@@ -1471,6 +1502,7 @@ type
     procedure TestArrayOobTrap;
     procedure TestI31;
     procedure TestGcMidBodyCollectionWalkable;
+    procedure TestGcInlineAllocFreeListReuse;
 
     { --- Wave 6: v128 SIMD via the Wasm.Interp.Vector leaves --------- }
     procedure TestSimdCompute;
@@ -3291,7 +3323,7 @@ begin
     [MakeValueI32($FF)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
   { struct.set (barriered) then read back. }
   Expect<Boolean>(DiffFresh(GcStructModuleBytes, 'setget',
-    [MakeValueI32(777)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
+    [MakeValueI32(777)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF})
 end;
 
 procedure TJitTests.TestArrayRoundTrip;
@@ -3323,6 +3355,17 @@ begin
   DiffFresh(I31ModuleBytes, 'null_trap', []);
   Expect<string>(TrapMessageOf(I31ModuleBytes, 'null_trap', []))
     .ToBe('null i31 reference');
+end;
+
+procedure TJitTests.TestGcInlineAllocFreeListReuse;
+begin
+  { Threshold 0 makes EVERY allocation collect, so the second struct.new runs
+    the compiled fast path over a cell the sweep just recycled. The result
+    must be exactly arg+1 under BOTH tiers — stale header or poison bytes
+    surfacing anywhere would diverge or fault. }
+  FDiffThreshold := 0;
+  Expect<Boolean>(DiffFresh(GcReuseModuleBytes, 'reuse',
+    [MakeValueI32(41)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
 end;
 
 procedure TJitTests.TestGcMidBodyCollectionWalkable;
@@ -3549,6 +3592,8 @@ begin
   Test('i31 ref/get_s/get_u and null trap match', TestI31);
   Test('a mid-body collection keeps a live ref (compiled frame is GC-walkable)',
     TestGcMidBodyCollectionWalkable);
+  Test('inline struct.new reuses a recycled cell across forced collects',
+    TestGcInlineAllocFreeListReuse);
 
   Test('v128 const/splat/extract/replace/add/eq/shuffle/swizzle match',
     TestSimdCompute);

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -230,6 +230,7 @@ uses
   {$IFDEF WASM_JIT_X64}
   Wasm.Jit.X64,
   {$ENDIF}
+  Wasm.Runtime.Gc,
   Wasm.Runtime.Traps;
 
 { --- the compiled-function dispatcher (the JitInvokeCompiled hook) --------
@@ -485,6 +486,8 @@ var
   ConstSlots: array[0..0] of UInt32;
   ConstSlotBits: array[0..0] of UInt64;
   GcShapes: array of UInt64;
+  GcAllocShapes: array of TWasmGcAllocShape;
+  GcAllocInfo: TWasmGcAllocInfo;
   UsePinnedMemory: Boolean;
   UsePinnedMemoryBase: Boolean;
   PinnedMemoryIndex: UInt32;
@@ -1587,6 +1590,165 @@ var
     end;
   end;
 
+  { Wave 11 — inline struct.new allocation. For a FIXED struct type the whole
+    Allocate sequence except collection is compile-time: layout size, size
+    class, cell size, field offsets. When the class size is a power of two
+    and every field is a numeric <=64-bit member, the backend emits the
+    free-list-hit fast path with these shapes; the helper path stays as the
+    miss branch and remains the only collect trigger. Ref fields stay off
+    (the barrier shape belongs to the helper), v128 fields, struct.new_default,
+    non-pow2 classes, and large objects all decline. Baked runtime offsets are
+    range-checked here so emission can use scaled-imm12 addressing directly. }
+  procedure AnalyzeGcInlineAlloc;
+  var
+    K, F, C, CanonIdx, ClassIndex, Log2Cell: Integer;
+    TypeIdx: UInt32;
+    Offset, Width, Size, CellSize, FreeOff: UInt32;
+    Ok: Boolean;
+    Comp: ^TWasmCompType;
+
+    function StorageWidthOf(const AStorage: TWasmStorageType): UInt32;
+    begin
+      if AStorage.IsPacked then
+      begin
+        if AStorage.PackedType = wpkI8 then
+          Result := 1
+        else
+          Result := 2;
+        Exit;
+      end;
+      case AStorage.ValueType.Kind of
+        wvkNum:
+          if (AStorage.ValueType.Num = wntI32) or
+            (AStorage.ValueType.Num = wntF32) then
+            Result := 4
+          else
+            Result := 8;
+        wvkVec:
+          Result := 16;
+      else
+        Result := 8;
+      end;
+    end;
+
+    function Log2OfPow2(const AValue: UInt32): Integer;
+    begin
+      if (AValue <> 0) and ((AValue and (AValue - 1)) = 0) then
+      begin
+        Result := 0;
+        while (UInt32(1) shl Result) <> AValue do
+          Inc(Result);
+      end
+      else
+        Result := -1;
+    end;
+
+  begin
+    SetLength(GcAllocShapes, Length(AFn^.Code));
+    for K := 0 to High(AFn^.Code) do
+      GcAllocShapes[K].Word := 0;
+    if UseNativeScalarCore then
+      Exit;
+    with WasmJitStoreAllocOffsets do
+    begin
+      GcAllocInfo.FHeapOffset := FHeapOffset;
+      GcAllocInfo.TierContextOffset := TierContextOffset;
+      GcAllocInfo.EngineTypeIdsOffset := EngineTypeIdsOffset;
+      if (FHeapOffset >= $8000) or (TierContextOffset >= $8000) or
+        (EngineTypeIdsOffset >= $8000) then
+        Exit;
+    end;
+    with WasmJitFrameOffsets do
+      if (CtxDepth >= $8000) or (CtxActs >= $8000) or
+        (ActInstance >= $8000) or (ActStride > High(UInt16)) then
+        Exit;
+    with WasmJitGcHeapOffsets do
+      if (HeapFFree0 + WASM_GC_CLASS_COUNT * 8 >= $8000) or
+        (HeapMarkState >= $8000) or (HeapBytesLive >= $8000) or
+        (HeapBytesAllocated >= $8000) or (HeapObjectCount >= $8000) or
+        (BlockBase >= $8000) or (BlockAllocated >= $8000) then
+        Exit;
+
+    for K := 0 to High(AFn^.Code) do
+    begin
+      if AFn^.Code[K].Op <> iroStructNew then
+        Continue;
+      TypeIdx := UInt32(AFn^.Code[K].Imm);
+      if TypeIdx >= UInt32(Length(AIr.CanonTypes)) then
+        Continue;
+      CanonIdx := Integer(AIr.TypeIndexToCanon[TypeIdx]);
+      if (CanonIdx < 0) or (CanonIdx >= Length(AIr.CanonTypes)) then
+        Continue;
+      Comp := @AIr.CanonTypes[CanonIdx].Comp;
+      if (Comp^.Kind <> wckStruct) then
+        Continue;
+      F := Length(Comp^.Struct.Fields);
+      if (F = 0) or (F > 16) then
+        Continue;
+
+      { Field walk — identical arithmetic to TWasmGcTypes' layout pass and
+        AnalyzeGcFieldAccess above: header 8, per-field align-up to storage
+        width, cumulative advance. }
+      Offset := 8;
+      Ok := True;
+      for C := 0 to F - 1 do
+      begin
+        Width := StorageWidthOf(Comp^.Struct.Fields[C].Storage);
+        if Width > 8 then
+        begin
+          Ok := False;
+          Break;
+        end;
+        if (not Comp^.Struct.Fields[C].Storage.IsPacked) and
+          (Comp^.Struct.Fields[C].Storage.ValueType.Kind = wvkRef) then
+        begin
+          Ok := False;
+          Break;
+        end;
+        Offset := (Offset + Width - 1) and not (Width - 1);
+        GcAllocShapes[K].Fields[C].Slot :=
+          IrAuxBlockItem(AFn^.AuxU32, AFn^.Code[K].A, UInt32(C));
+        GcAllocShapes[K].Fields[C].Offset := Offset;
+        GcAllocShapes[K].Fields[C].Width := Width;
+        Offset := Offset + Width;
+      end;
+      if not Ok then
+        Continue;
+
+      { Size-class math mirrors TWasmGcHeap.Allocate exactly: Layout.Size is
+        the align-up-8 of the field span, sizes below the first class bump to
+        it, ClassOf takes the first class >= the size. A power-of-two class
+        means CellSize == Size exactly, so the cell tail past the aligned
+        layout is zero bytes and nothing needs an inline zero fill. }
+      Size := (Offset + 7) and not UInt32(7);
+      if Size < WASM_GC_SIZE_CLASSES[0] then
+        Size := WASM_GC_SIZE_CLASSES[0];
+      ClassIndex := -1;
+      for C := 0 to WASM_GC_CLASS_COUNT - 1 do
+        if Size <= WASM_GC_SIZE_CLASSES[C] then
+        begin
+          ClassIndex := C;
+          Break;
+        end;
+      if ClassIndex < 0 then
+        Continue;
+      CellSize := WASM_GC_SIZE_CLASSES[ClassIndex];
+      Log2Cell := Log2OfPow2(CellSize);
+      if Log2Cell < 0 then
+        Continue;
+      FreeOff := WasmJitGcHeapOffsets.HeapFFree0 + UInt32(ClassIndex) * 8;
+      if (FreeOff >= $8000) or (TypeIdx >= 4096) then
+        Continue;
+
+      { bit0 enabled | bits8-15 count | bits16-23 log2(CellSize) |
+        bits24-31 class index }
+      GcAllocShapes[K].Word := 1 or
+        (UInt64(F) shl 8) or
+        (UInt64(Log2Cell) shl 16) or
+        (UInt64(ClassIndex) shl 24);
+    end;
+  end;
+
   procedure AnalyzePinnedMemory;
   var
     K: Integer;
@@ -1736,6 +1898,7 @@ begin
     AnalyzeConstSlots;
     {$IFDEF WASM_JIT_ARM64}
     AnalyzeGcFieldAccess;
+    AnalyzeGcInlineAlloc;
     {$ENDIF}
     {$IFDEF WASM_JIT_ARM64}
     AnalyzeDynamicWriteBack;
@@ -1869,7 +2032,7 @@ begin
             UsePinnedMemory, UsePinnedMemoryBase, UseExtendedFrame,
             UseNativeScalarCore, AFn^.RegisterCount, NativeParamReg,
             NativeResultReg, NativeCoreLabel, NativeExhaustedLabel, ArmCache,
-            @GcShapes[0]);
+            @GcShapes[0], @GcAllocShapes[0], GcAllocInfo);
       end;
       {$ENDIF}
       {$IFDEF WASM_JIT_X64}

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -486,8 +486,10 @@ var
   ConstSlots: array[0..0] of UInt32;
   ConstSlotBits: array[0..0] of UInt64;
   GcShapes: array of UInt64;
+  {$IFDEF WASM_JIT_ARM64}
   GcAllocShapes: array of TWasmGcAllocShape;
   GcAllocInfo: TWasmGcAllocInfo;
+  {$ENDIF}
   UsePinnedMemory: Boolean;
   UsePinnedMemoryBase: Boolean;
   PinnedMemoryIndex: UInt32;
@@ -1590,6 +1592,7 @@ var
     end;
   end;
 
+  {$IFDEF WASM_JIT_ARM64}
   { Wave 11 — inline struct.new allocation. For a FIXED struct type the whole
     Allocate sequence except collection is compile-time: layout size, size
     class, cell size, field offsets. When the class size is a power of two
@@ -1734,7 +1737,7 @@ var
         Continue;
       CellSize := WASM_GC_SIZE_CLASSES[ClassIndex];
       Log2Cell := Log2OfPow2(CellSize);
-      if Log2Cell < 0 then
+      if (Log2Cell < 0) or (CellSize <> Size) then
         Continue;
       FreeOff := WasmJitGcHeapOffsets.HeapFFree0 + UInt32(ClassIndex) * 8;
       if (FreeOff >= $8000) or (TypeIdx >= 4096) then
@@ -1748,6 +1751,7 @@ var
         (UInt64(ClassIndex) shl 24);
     end;
   end;
+  {$ENDIF}
 
   procedure AnalyzePinnedMemory;
   var

--- a/source/units/Wasm.Runtime.Gc.pas
+++ b/source/units/Wasm.Runtime.Gc.pas
@@ -768,6 +768,26 @@ function GcConvertInner(const ARef: TWasmRef): TWasmRef;
   this map through Wasm.Runtime.Store.IsRefOfRefType unchanged. }
 function GcAbsKindOf(const AKind: TWasmObjKind): TWasmAbsHeapType;
 
+{ The TWasmGcHeap / TWasmGcBlock field offsets the JIT's inline-allocation
+  fast path bakes into generated code (wave 11). The heap fields are private,
+  so the probe lives in this unit and answers through a throwaway
+  Types+Heap pair that is constructed once, measured, and freed; only field
+  ADDRESSES are ever taken. Block offsets come from an uninitialised record
+  local the same way WasmJitFrameOffsets reads records — FPC nils the managed
+  Allocated field at declaration and nothing dereferences it. }
+type
+  TWasmJitGcOffsets = record
+    HeapFFree0: NativeUInt;        { TWasmGcHeap.FFree[0] — class k at +k*8 }
+    HeapMarkState: NativeUInt;     { TWasmGcHeap.FMarkState }
+    HeapBytesLive: NativeUInt;     { TWasmGcHeap.FBytesLive }
+    HeapBytesAllocated: NativeUInt;
+    HeapObjectCount: NativeUInt;   { TWasmGcHeap.FObjectCount }
+    BlockBase: NativeUInt;         { TWasmGcBlock.Base }
+    BlockAllocated: NativeUInt;    { TWasmGcBlock.Allocated (dyn-array ptr) }
+  end;
+
+function WasmJitGcHeapOffsets: TWasmJitGcOffsets;
+
 implementation
 
 type
@@ -784,6 +804,50 @@ type
   that reallocated FLayouts during that window would dangle the pointer. }
 threadvar
   GWasmGcCollecting: Boolean;
+
+var
+  GJitGcOffsets: TWasmJitGcOffsets;
+  GJitGcOffsetsValid: Boolean = False;
+
+function WasmJitGcHeapOffsets: TWasmJitGcOffsets;
+var
+  Types: TWasmGcTypes;
+  Heap: TWasmGcHeap;
+  Block: TWasmGcBlock;
+begin
+  { Layout is fixed per class, so the answer is computed once over a real,
+    empty heap and cached. Construction has no observable side effect: an
+    empty heap owns no blocks, and the borrowed Types outlives it. }
+  if not GJitGcOffsetsValid then
+  begin
+    Types := TWasmGcTypes.Create;
+    try
+      Heap := TWasmGcHeap.Create(Types);
+      try
+        GJitGcOffsets.HeapFFree0 :=
+          PtrUInt(@Heap.FFree[0]) - PtrUInt(Pointer(Heap));
+        GJitGcOffsets.HeapMarkState :=
+          PtrUInt(@Heap.FMarkState) - PtrUInt(Pointer(Heap));
+        GJitGcOffsets.HeapBytesLive :=
+          PtrUInt(@Heap.FBytesLive) - PtrUInt(Pointer(Heap));
+        GJitGcOffsets.HeapBytesAllocated :=
+          PtrUInt(@Heap.FBytesAllocated) - PtrUInt(Pointer(Heap));
+        GJitGcOffsets.HeapObjectCount :=
+          PtrUInt(@Heap.FObjectCount) - PtrUInt(Pointer(Heap));
+        GJitGcOffsets.BlockBase :=
+          PtrUInt(@Block.Base) - PtrUInt(@Block);
+        GJitGcOffsets.BlockAllocated :=
+          PtrUInt(@Block.Allocated) - PtrUInt(@Block);
+      finally
+        Heap.Free;
+      end;
+    finally
+      Types.Free;
+    end;
+    GJitGcOffsetsValid := True;
+  end;
+  Result := GJitGcOffsets;
+end;
 
 { --- allocation bitmap --------------------------------------------------- }
 

--- a/source/units/Wasm.Runtime.Store.pas
+++ b/source/units/Wasm.Runtime.Store.pas
@@ -974,11 +974,75 @@ type
     MemInstStride: NativeUInt;       { SizeOf(TWasmMemoryInst) }
     MemBase: NativeUInt;             { TWasmMemoryInst.Base }
     MemByteSize: NativeUInt;         { TWasmMemoryInst.ByteSize }
+    { Wave 11 inline-allocation fast path: the three runtime anchors generated
+      code walks for a struct.new — the store's GC heap, the per-store
+      interpreter context, and the instance's engine-id map. All are folded
+      into the AOT ABI fingerprint like every other baked offset. }
+    StoreFHeap: NativeUInt;          { TWasmStore.FHeap }
+    StoreTierContext: NativeUInt;    { TWasmStore.TierContext }
+    InstEngineTypeIds: NativeUInt;   { TWasmModuleInstance.EngineTypeIds }
   end;
 
 function WasmJitOffsets(const AStore: TWasmStore): TWasmJitOffsets;
 
+{ The wave-11 inline-allocation anchors as a layout-only, parameterless
+  probe: the store-relative heap and tier-context offsets plus the module
+  instance's engine-id map offset. Computed once over a throwaway
+  Engine+Store+Instance trio and cached — object layouts are fixed per
+  class, so one measurement answers for every future instance, and no live
+  store is needed at JIT staging time. }
+type
+  TWasmJitStoreAllocOffsets = record
+    FHeapOffset: NativeUInt;
+    TierContextOffset: NativeUInt;
+    EngineTypeIdsOffset: NativeUInt;
+  end;
+
+function WasmJitStoreAllocOffsets: TWasmJitStoreAllocOffsets;
+
 implementation
+
+var
+  { Lazy cache for WasmJitOffsets' InstEngineTypeIds probe; -1 until measured. }
+  GJitInstEngineTypeIdsOffset: NativeInt = -1;
+
+var
+  GJitStoreAllocOffsets: TWasmJitStoreAllocOffsets;
+  GJitStoreAllocOffsetsValid: Boolean = False;
+
+function WasmJitStoreAllocOffsets: TWasmJitStoreAllocOffsets;
+var
+  Engine: TWasmEngine;
+  Store: TWasmStore;
+  Inst: TWasmModuleInstance;
+begin
+  if not GJitStoreAllocOffsetsValid then
+  begin
+    Engine := TWasmEngine.Create;
+    try
+      Store := TWasmStore.Create(Engine);
+      try
+        GJitStoreAllocOffsets.FHeapOffset :=
+          PtrUInt(@Store.FHeap) - PtrUInt(Pointer(Store));
+        GJitStoreAllocOffsets.TierContextOffset :=
+          PtrUInt(@Store.TierContext) - PtrUInt(Pointer(Store));
+        Inst := TWasmModuleInstance.Create;
+        try
+          GJitStoreAllocOffsets.EngineTypeIdsOffset :=
+            PtrUInt(@Inst.EngineTypeIds) - PtrUInt(Pointer(Inst));
+        finally
+          Inst.Free;
+        end;
+      finally
+        Store.Free;
+      end;
+    finally
+      Engine.Free;
+    end;
+    GJitStoreAllocOffsetsValid := True;
+  end;
+  Result := GJitStoreAllocOffsets;
+end;
 
 { --- module space to engine space ---------------------------------------- }
 
@@ -2293,6 +2357,26 @@ function WasmJitOffsets(const AStore: TWasmStore): TWasmJitOffsets;
 var
   F: TWasmFuncInst;
   M: TWasmMemoryInst;
+  Inst: TWasmModuleInstance;
+
+  function ProbeEngineTypeIds: NativeUInt;
+  begin
+    { The engine-id map is one field on a plain class, so a throwaway
+      instance answers the offset; cached because the fingerprint and every
+      staged allocating function ask for it. }
+    if GJitInstEngineTypeIdsOffset < 0 then
+    begin
+      Inst := TWasmModuleInstance.Create;
+      try
+        GJitInstEngineTypeIdsOffset :=
+          NativeInt(PtrUInt(@Inst.EngineTypeIds) - PtrUInt(Pointer(Inst)));
+      finally
+        Inst.Free;
+      end;
+    end;
+    Result := NativeUInt(GJitInstEngineTypeIdsOffset);
+  end;
+
 begin
   { Only the ADDRESSES of fields are taken, never their values, so the
     uninitialised locals F and M are not read. }
@@ -2301,6 +2385,10 @@ begin
     PtrUInt(@AStore.EpochSnapshot) - PtrUInt(Pointer(AStore));
   Result.StoreJitHelperTable :=
     PtrUInt(@AStore.JitHelperTable) - PtrUInt(Pointer(AStore));
+  Result.StoreFHeap := PtrUInt(@AStore.FHeap) - PtrUInt(Pointer(AStore));
+  Result.StoreTierContext :=
+    PtrUInt(@AStore.TierContext) - PtrUInt(Pointer(AStore));
+  Result.InstEngineTypeIds := ProbeEngineTypeIds;
   Result.FuncInstStride := SizeOf(TWasmFuncInst);
   Result.FuncKind := PtrUInt(@F.Kind) - PtrUInt(@F);
   Result.FuncCompiledEntry := PtrUInt(@F.CompiledEntry) - PtrUInt(@F);


### PR DESCRIPTION
## Summary

Wave 11 of the Wasmtime-gap optimization series: eligible `struct.new`
allocations in the arm64 JIT/AOT no longer pay a runtime-helper crossing.
The backend now emits the whole free-list-hit allocation inline —
context-chain engine-id walk, head load, pop, block-bitmap mark, the three
host-visible counters, a two-half header, and baked numeric field stores —
with the destination reference published last. A free-list miss branches
into the unchanged generic (helper) emission, which remains the only
collection trigger at allocation sites (ADR-0011), and every safepoint,
stack-map, trap, and memory invariant is untouched.

Eligibility is decided once by a driver analysis that mirrors
`TWasmGcHeap.Allocate`'s size-class math exactly: power-of-two classes only
(16/32/64/128/256, where `CellSize == AlignUp(layoutSize, 8)` so the cell
tail past the layout is zero bytes by construction), all fields numeric and
at most 64 bits wide, arity ≤ 16, and every baked offset within its scaled
immediate range. Reference and v128 fields, `struct.new_default`,
non-power-of-two classes, and large objects keep the helper path.

New probes expose the private GC-heap/block offsets and the store-side
anchors (heap, tier context, instance engine-id map) that the sequence
bakes. All are folded into the AOT ABI fingerprint, which bumps to revision
15, so artifacts produced by older builds fail closed.

Two defects were caught inside the wave's own differential gates and fixed
before acceptance: an MADD encoder base typo (`$8B` vs `$9B`) in the new
walk, and header stores that preceded the link pop (the link word shares
its qword with the header low half). Neither survives in the tree; both
shapes are now pinned.

Measured on Apple M5 Max (serialized BASE-CAND-CAND-BASE under the perf
gate, best profile, one warm-up discarded, seven samples per leg):

- gc: 76.209/76.511 ms → 45.780/45.773 ms (**−39.9% both orders**;
  spreads disjoint). Against same-schedule Wasmtime-AOT the gc workload
  moves from ~2.5× to **1.61×**.
- Guards flat within this host's documented noise bands: fib, call,
  host-call, simd, startup deltas < ±2%; loop/memory-leg swings appeared
  identically on both binaries across later legs and are host drift, not
  candidate effects.

Remaining out-of-band workloads for later waves: call (~2.30×), simd
(~1.82×), gc residual (1.61×).

## Testing

- New differential test: threshold-0 forced collects drive the compiled
  fast path over a recycled (poisoned) cell; both tiers must observe the
  identical fresh value.
- New 43-word pin of the emitted fast-path sequence for the canonical
  single-i32-field shape, including branch resolution.
- Full gate on the exact head: `lwpt install --frozen`, `lwpt format
  --check`, dev + release builds, 44/44 unit suites, Markdown lint,
  generated-agent check, diff check.
- Pinned corpus byte-identical in interpreter/JIT/AOT:
  pass=65851 fail=368 skip=904 staged=0 errors=0 (compiled=8799).
- The x64 backend is inert this wave (the analyzer and template are
  arm64-gated); Windows and 32-bit targets remain interpreter-only.

## CI repair\n\n- Guard arm64-only allocation-shape state and analysis so Linux/x86-64 keeps the x64 backend inert and compiles cleanly.\n- Enforce the documented exact-size eligibility rule and remove the temporary emitter diagnostic.\n- Verified with the macOS/arm64 JIT and emitter suites, an Ubuntu Noble/x86-64 release build plus JIT/X64 suites, and the full 44-suite universal gate.\n\n## Linked issues

None — this continues the measured optimization series recorded in
`.agent/HANDOFF.md` (wave 11 design record).

