### PR TITLE
perf(jit): accelerate Arm64 array and SIMD hot paths

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,76 @@
 # Handoff
 
-Updated: 2026-08-23 (Wave 12 Arm64 fixed-array access accepted)
+Updated: 2026-08-23 (Wave 13 Arm64 adjacent-vector-result fusion accepted)
+
+## Wave 13 — adjacent Arm64 vector-result moves fused ACCEPTED
+
+- Continued from the accepted Wave 12 integration head `675213a` after a
+  fresh fetch confirmed `origin/main@1a89b4779e71b855cbbac7d90ebc69aee31b6295`
+  was unchanged. The accepted implementation is `93b3278` (`perf(jit): fuse
+  adjacent Arm64 vector result moves`) plus the required correctness follow-up
+  `85b2737` (`fix(jit): preserve live Arm64 vector temporaries`), both local
+  and unpushed on `t3code/optimize-runtime-parallel`.
+- The fresh seven-sample best/AOT baseline at `675213a` measured call 136.516
+  ms versus Wasmtime 60.037 ms (2.27x), SIMD 8.429 versus 4.572 ms (1.84x),
+  memory-load 45.281 versus 30.239 ms (1.50x), and GC 24.582 versus 26.903 ms
+  (0.91x). Scaled self-checking `sample(1)` profiles put effectively every
+  call and SIMD sample in generated code, so three isolated lanes covered
+  local call instruction selection, adjacent SIMD traffic, and the borderline
+  memory-load path.
+- The retained Arm64-only compile plan recognizes a native v128 producer
+  immediately followed by `iroMoveVec` into a visible local/result slot. It
+  redirects the producer to that canonical slot and skips the redundant
+  Q-register load/store pair only when the producer temp is a non-visible
+  `wvkVec`, the destination is visible, neither instruction is a branch
+  target, and an `IR_OP_INFO`-driven source scan proves the temp has exactly
+  one use (including direct fields, Imm source registers, and A-aux argument
+  lists). No vector value is cached across an instruction or control-flow
+  boundary; the static-cache, Q-host-constant, prologue, and alignment designs
+  rejected in earlier waves remain absent.
+- Independent review caught a real defect in the first measured commit before
+  integration: `local.tee` writes the visible local but deliberately keeps the
+  producer temporary live on the operand stack. The initial peephole left that
+  temp unwritten. A fresh-store `tee_both` differential reproduced the failure
+  (a same-store differential could be masked by interpreter residue); the
+  follow-up single-use proof now retains the 180-byte unfused shape for that
+  case while the safe shapes remain 148/176 bytes.
+- The corrected exact candidate (`0eb642df...`) passed a fresh serialized
+  B-C-C-B: **8.602 -> 5.742 -> 5.827 -> 8.809 ms**, improving SIMD 33.25%
+  forward and 33.85% reverse. Wasmtime-normalized ratios improved from
+  1.736x/1.762x to 1.189x/1.176x (-31.54%/-33.25%). Raw results are
+  `/tmp/w13-simd-guarded-{base1,cand1,cand2,base2}.json`. The integrated
+  seven-sample full schedule independently measured SIMD at 5.412 ms versus
+  Wasmtime 4.450 ms (1.22x). Its release binary
+  `/tmp/wasmlight-wave13-integrated.Vsucn8/wasmlight` is byte-identical to the
+  guarded lane binary.
+- The full schedule's scalar call/memory medians retained their documented
+  broad dispersion. Deterministic AOT comparison proved every non-SIMD
+  workload artifact byte-identical between the retained Wave 12 and integrated
+  Wave 13 binaries; only `simd.waot` changed, so those scalar swings are not
+  codegen regressions from this wave.
+- REJECTED and fully reverted with clean, uncommitted lane branches: (1) a
+  scaled-immediate `LDR W` removed two instructions from the hot direct-call
+  lookup, but the only clean forward pair was effectively flat (145.124 ->
+  143.941 ms, -0.82%) and the reverse baseline suffered corroborated host
+  drift; artifacts are under
+  `/tmp/wasmlight-wave13-call-measure/{base1,cand1,cand2,base2}.json`.
+  (2) preferring the widest loop constant reduced the memory-load loop from
+  16 to 14 instructions, but candidate medians differed by 23.9% and the
+  apparent gains (14.30%/3.90%) overlapped 21-41% dispersion; artifacts are
+  `/tmp/w13-memory-{base1,cand1,cand2,base2}.json`.
+- Exact integrated gates pass: frozen install; release build 3/3; format 91/91;
+  agents check; diff check; all 44 unit programs. The recursive pinned corpus
+  at `de54fd27` is byte-identical across interpreter/JIT/AOT:
+  files=288 errors=0 pass=65851 fail=368 skip=904 staged=0 total=67123, with
+  compiled=8799 in JIT/AOT. The corpus was read from the clean pinned checkout
+  under `t3code-b5095128` because this isolated worktree had no local fetched
+  mirror. `lantaarn-spike` and `wasmx64` were gracefully paused for timing and
+  restored to running afterward.
+- Begin the next wave from `85b2737`. SIMD is now inside the 1.43x Wasmtime
+  goal and GC remains faster on its diagnostic. Direct calls remain the clear
+  out-of-band gap, but do not retry activation-wide hoisting, per-instance
+  call tables, or the scaled-LDR-only candidate; otherwise prioritize x64
+  mirrors of accepted Arm64 struct/array GC paths.
 
 ## Wave 12 — fixed-type scalar array access natively on Arm64 ACCEPTED
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,83 @@
 # Handoff
 
-Updated: 2026-08-23 (PR #19 CI repair validated locally)
+Updated: 2026-08-23 (Wave 12 Arm64 fixed-array access accepted)
+
+## Wave 12 — fixed-type scalar array access natively on Arm64 ACCEPTED
+
+- Exact starting point was fetched `origin/main@1a89b4779e71b855cbbac7d90ebc69aee31b6295`
+  after PR #19 merged green. Delivery branch
+  `t3code/optimize-runtime-parallel` now points at accepted commit `cbbc09e`
+  (`perf(jit): emit fixed-type array access natively on arm64`); it is local
+  and unpushed. The retained exact-main release binary is
+  `/tmp/wasmlight-wave12-base.ySYtuH/wasmlight`, SHA-256 `364aa3bd…`; the
+  integrated release is `f103d8f7…`, byte-identical to the accepted lane
+  binary.
+- Fresh exact-main comparison (Apple M5 Max, macOS 26.5.2/arm64, best/AOT,
+  one warm-up discarded, seven samples) put gc at 45.705 ms versus Wasmtime
+  28.858 ms. A 4-second `sample(1)` profile of a self-checking 250M-iteration
+  scaled module attributed the largest named leaf to `ArraySet` (254 samples),
+  plus layout resolution 189, `GcRefTypeId` 122, array length 79, the v1 empty
+  write barrier 44, and 85 runtime IR-aux reads. This confirmed fixed-type
+  array access as the next bottleneck on current main.
+- Mechanism: the driver bakes validated fixed-array width, signedness, element
+  base, and reference shape into the existing per-instruction GC shape word.
+  The Arm64 emitter performs null, kind/invariant, and unsigned bounds checks
+  in the runtime's original order, then uses scaled `[base,Windex,UXTW]`
+  loads/stores for scalar `array.get/get_s/get_u/set`. A validator-unreachable
+  kind mismatch retains the unchanged runtime `EWasmInternal` helper route.
+  Reference stores are direct because the stop-the-world v1 write barrier is
+  deliberately empty and the store cannot collect; the code comment requires
+  reference shapes to decline or gain a PIC helper before that collector
+  policy can become non-empty. No process/store/type address is baked, so AOT
+  PIC, fingerprint, and artifact compatibility are unchanged.
+- Clean serialized lane B-C-C-B under the persistent `fcntl` performance lock
+  (release, one warm-up, seven samples) measured gc
+  **44.876 -> 25.883 -> 25.663 -> 43.704 ms**: -42.33% forward and -41.28%
+  reverse, with fully disjoint ranges (bases 43.616-45.091 / 43.068-44.367;
+  candidates 25.529-26.275 / 25.339-26.157). Same-schedule candidate/Wasmtime
+  ratios were 0.92x/0.90x. Raw full schedules are
+  `/tmp/w12-array-{base1,cand1,cand2,base2}.json`.
+- The post-integration target-only B-C-C-B independently confirmed the exact
+  combined state: **43.551 -> 24.925 -> 24.182 -> 43.631 ms**, or -42.77%
+  forward and -44.57% reverse; ranges remained disjoint. Raw results are
+  `/tmp/w12-integrated-{base1,cand1,cand2,base2}.json`. The full lane schedule
+  found no material guard regression: startup/fib/host-call stayed in their
+  prior bands; loop/SIMD movement co-drifted with peers; memory and call kept
+  their already documented broad, bimodal within-leg spreads.
+- Correctness on exact `cbbc09e`: focused Arm64 27/27 and JIT 67/67; all 44
+  unit programs; release builds of all three apps; frozen install; format;
+  agents check; diff check. The recursive pinned corpus is byte-identical in
+  interpreter/JIT/AOT: files=288 errors=0 pass=65851 fail=368 skip=904
+  staged=0 total=67123, compiled=8799 in JIT/AOT. New differentials force a
+  collection after a reference-array store (the stored struct is reachable
+  only through the array), pin null-before-bounds, and keep an unrelated dirty
+  cached local live across native `array.get`.
+- A review caught and fixed the initial candidate's only correctness defect
+  before measurement: a common cache invalidation could discard an unrelated
+  dirty dynamic value. Native gets now use `Arm64CachedStore`; native stores
+  preserve the existing cache state; the new `dirty` differential fails the
+  old form. No result from the earlier loaded-VM/compiler period was accepted.
+- REJECTED lanes, fully reverted with clean worktrees and no commits:
+  (1) direct-call target/cap hoisting expanded the Arm64 frame and added 276
+  lines but clean B-C-C-B paired medians regressed call by 8.56% (149.282 ->
+  162.066 ms), guards flat; raw files under
+  `/tmp/wasmlight-wave12-call-measure/`. (2) SIMD scalar static-cache admission
+  was recognized as the already-rejected Wave 3 shape; one clean forward leg
+  made the loop smaller (57 -> 42 A64 instructions) but regressed SIMD 12.10%
+  (9.183 -> 10.294 ms, disjoint ranges), so reverse legs were deliberately not
+  repeated; evidence is `/tmp/wasmlight-wave12-simd-evidence/`.
+- Process notes: current `bench.py` uses `fcntl.flock` on the persistent
+  zero-byte regular `/tmp/wasmlight-perf-gate.lock`; do not replace it with the
+  older directory-lock protocol. Harness locks do not serialize unrelated lane
+  compilers/probes, so the integration owner must grant explicit measurement
+  windows. `lantaarn-spike` and `wasmx64` were gracefully paused for accepted
+  timing after vmgr reached ~3 cores, then both restored to their prior running
+  state.
+- Remaining out-of-band priorities after this wave: direct calls (the hoist
+  design lost; re-profile before a genuinely different mechanism), SIMD (do
+  not retry static-cache admission or alignment), then x64 mirrors of the
+  accepted Arm64 struct/array GC paths. GC itself is now faster than Wasmtime
+  on this diagnostic shape and is no longer the first gap.
 
 ## PR #19 CI repair
 
@@ -15,8 +92,8 @@ Updated: 2026-08-23 (PR #19 CI repair validated locally)
   Ubuntu Noble/x86-64 release builds all three programs and passes the JIT +
   X64 suites; the universal macOS gate passes frozen install, format, all
   three builds, all 44 test programs, `lwpt agents --check`, and diff check.
-- Delivery stays on draft PR #19. Re-query its exact head and checks rather
-  than relying on this handoff for live CI state.
+- PR #19 merged as `1a89b47` with every configured check green. Re-query its
+  exact head and checks rather than relying on this handoff for live CI state.
 
 ## Wave 11 — inline struct.new allocation fast path ACCEPTED
 

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -542,6 +542,7 @@ procedure Arm64ResolvePatches(const ABuf: TWasmCodeBuffer);
   freshly per invocation — so nothing about the host process is ever baked, and
   this also subsumes the old Fix-C @AIns-by-reference concern. }
 function Arm64CanEmitOp(const AOp: TWasmIrOp): Boolean;
+function Arm64NativeVecOp(const AOp: TWasmIrOp): Boolean;
 function Arm64EmitOp(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
   const AInsIndex: UInt32; const AUsePinnedMemory: Boolean = False;

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -591,6 +591,12 @@ function Arm64EmitOpCached(const ABuf: TWasmCodeBuffer;
 procedure Arm64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AShape: UInt64;
   var ACache: TArm64RegCache);
+{ Fixed-type scalar array access. A kind mismatch takes the unchanged helper
+  route so the runtime's internal invariant remains authoritative; null and
+  bounds traps are emitted in their original order on the native path. }
+procedure Arm64EmitGcArrayAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AInsIndex: UInt32; const AShape: UInt64;
+  var ACache: TArm64RegCache);
 { Wave 11 — the inline struct.new fast path. Emits the free-list-hit
   allocation straight line (pop, bitmap, counters, header, baked numeric
   fields) and jumps to ADoneLabel; the caller binds its slow label at the
@@ -1082,6 +1088,123 @@ begin
   end;
 end;
 
+procedure Arm64EmitGcArrayAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AInsIndex: UInt32; const AShape: UInt64;
+  var ACache: TArm64RegCache);
+var
+  ObjSlot, IndexSlot: UInt32;
+  Width: Byte;
+  LdrOp, StrOp: UInt32;
+  Signed: Boolean;
+  Val: Byte;
+  NonNull, KindFallback, InBounds, Done: TWasmJitLabel;
+
+  function ScaledRegOffset(const APrefix: UInt32; const ARt: Byte): UInt32;
+  begin
+    { S=1 scales Wm by the access width; the array index is i32, so UXTW
+      keeps its full unsigned range. }
+    Result := Arm64MemRegOffset(APrefix, ARt, ARM64_REG_T0,
+      ARM64_REG_T1, False) or $1000;
+  end;
+
+begin
+  Width := Byte((AShape shr 8) and $FF);
+  Signed := (AShape and 2) <> 0;
+  if AIns.Op = iroArraySet then
+  begin
+    ObjSlot := AIns.Dest;
+    IndexSlot := AIns.A;
+  end
+  else
+  begin
+    ObjSlot := AIns.A;
+    IndexSlot := AIns.B;
+  end;
+
+  Arm64CachedLoad(ABuf, ACache, ARM64_REG_T0, ObjSlot);
+  Arm64CachedLoad(ABuf, ACache, ARM64_REG_T1, IndexSlot);
+  NonNull := ABuf.NewLabel;
+  KindFallback := ABuf.NewLabel;
+  InBounds := ABuf.NewLabel;
+  Done := ABuf.NewLabel;
+
+  EmitCbnzTo(ABuf, ARM64_REG_T0, NonNull);
+  Arm64EmitLoadImm32(ABuf, 0, Ord(wtkNullArrayReference));
+  Arm64EmitCallHelper(ABuf, aohTrapKind);
+  ABuf.BindLabel(NonNull);
+
+  { Preserve ResolveElement's null -> layout/kind -> bounds order. The kind
+    mismatch is validator-unreachable, so the cold helper call exists only to
+    retain its exact EWasmInternal invariant rather than inventing a backend
+    error path. }
+  Arm64EmitLdrW(ABuf, ARM64_REG_T2, ARM64_REG_T0, 0);
+  ABuf.EmitU32(Arm64LsrImmW(ARM64_REG_T2, ARM64_REG_T2,
+    WASM_OBJ_KIND_SHIFT));
+  ABuf.EmitU32(Arm64AndLowMaskImmW(ARM64_REG_T2, ARM64_REG_T2, 3));
+  ABuf.EmitU32(Arm64SubImmX(ARM64_REG_T2, ARM64_REG_T2, Ord(wokArray)));
+  ABuf.EmitU32(Arm64CmpX(ARM64_REG_T2, ARM64_REG_ZR));
+  EmitBCondTo(ABuf, ARM64_COND_NE, KindFallback);
+
+  Arm64EmitLdrW(ABuf, ARM64_REG_T2, ARM64_REG_T0,
+    WASM_ARRAY_LENGTH_OFFSET);
+  ABuf.EmitU32(Arm64CmpW(ARM64_REG_T1, ARM64_REG_T2));
+  EmitBCondTo(ABuf, ARM64_COND_LO, InBounds);
+  Arm64EmitLoadImm32(ABuf, 0, Ord(wtkArrayOutOfBounds));
+  Arm64EmitCallHelper(ABuf, aohTrapKind);
+  ABuf.BindLabel(InBounds);
+  ABuf.EmitU32(Arm64AddImmX(ARM64_REG_T0, ARM64_REG_T0,
+    WASM_ARRAY_ELEMS_OFFSET));
+
+  if AIns.Op = iroArraySet then
+  begin
+    Val := Arm64CachedSourceReg(ABuf, ACache, AIns.B, ARM64_REG_T2);
+    if Width = 1 then
+      StrOp := $39000000
+    else if Width = 2 then
+      StrOp := $79000000
+    else if Width = 4 then
+      StrOp := $B9000000
+    else
+      StrOp := $F9000000;
+    ABuf.EmitU32(ScaledRegOffset(StrOp, Val));
+    { The v1 barrier is deliberately empty and a store cannot collect, so the
+      direct reference write has the same visibility semantics as ArraySet.
+      A non-empty future barrier must make reference shapes decline here or
+      gain a dedicated PIC helper before it changes collector policy. }
+  end
+  else
+  begin
+    if Width = 1 then
+      if Signed then
+        LdrOp := $39C00000
+      else
+        LdrOp := $39400000
+    else if Width = 2 then
+      if Signed then
+        LdrOp := $79C00000
+      else
+        LdrOp := $79400000
+    else if Width = 4 then
+      LdrOp := $B9400000
+    else
+      LdrOp := $F9400000;
+    ABuf.EmitU32(ScaledRegOffset(LdrOp, ARM64_REG_T2));
+    Arm64CachedStore(ABuf, ACache, ARM64_REG_T2, AIns.Dest);
+  end;
+  EmitBranchTo(ABuf, UInt32(Done));
+
+  ABuf.BindLabel(KindFallback);
+  { ResolveElement raises before consulting index/value on this path. Publish
+    the already-loaded object so JitRtDispatch observes the exact ref even if
+    its source slot currently lives only in the dynamic cache. }
+  StX(ABuf, ARM64_REG_T0, ObjSlot);
+  ABuf.EmitU32(Arm64MovReg(0, ARM64_REG_STORE));
+  ABuf.EmitU32(Arm64MovReg(1, ARM64_REG_REGFILE));
+  Arm64EmitIrInsPtr(ABuf, 2, AInsIndex);
+  Arm64EmitCallHelper(ABuf, aohRtDispatch);
+  ABuf.BindLabel(Done);
+end;
+
 procedure Arm64EmitInlineStructNew(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AShape: TWasmGcAllocShape;
   const AInfo: TWasmGcAllocInfo; var ACache: TArm64RegCache;
@@ -1409,7 +1532,11 @@ begin
     if (AGcShapes <> nil) and
       ((AGcShapes[AInsIndex] and 1) <> 0) then
     begin
-      Arm64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
+      if (AGcShapes[AInsIndex] and 4) <> 0 then
+        Arm64EmitGcArrayAccess(ABuf, AIns, AInsIndex,
+          AGcShapes[AInsIndex], ACache)
+      else
+        Arm64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
       Exit;
     end;
     { Wave 11: an eligible struct.new takes the inline free-list fast path;

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -1197,12 +1197,13 @@ begin
       BLit([$60, $00, $01, $7F]),                    { 0: ()->i32 }
       BLit([$60, $01, $7F, $01, $7F])])),            { 1: (i32)->i32 }
     Sect(3, VecOf([BLit([$00]), BLit([$00]), BLit([$01]),
-      BLit([$01])])),
+      BLit([$01]), BLit([$01])])),
     Sect(7, VecOf([
       ExportEntry('setget', $00, 0),
       ExportEntry('tee', $00, 1),
       ExportEntry('move', $00, 2),
-      ExportEntry('move2', $00, 3)])),
+      ExportEntry('move2', $00, 3),
+      ExportEntry('tee_both', $00, 4)])),
     Sect(10, VecOf([
       { const -> local.set -> local.get -> extract lane 2 = 0x08090A0B }
       CodeEntry(Cat([BLit([$01, $01, $7B]), Fd(12),
@@ -1227,7 +1228,12 @@ begin
         $99, $AA, $BB, $CC, $DD, $EE, $FF, $07]),
         BLit([$21, $01]), BLit([$20, $00]), Fd(17), BLit([$20, $00]),
         Fd(28), BLit([$02]),
-        BLit([$21, $02]), BLit([$20, $02]), Fd(27), BLit([$02, $0B])]))
+        BLit([$21, $02]), BLit([$20, $02]), Fd(27), BLit([$02, $0B])])),
+      { local.tee's result remains the producer temporary while local.get
+        reads the visible local. Both lane extracts must observe the splat. }
+      CodeEntry(Cat([BLit([$01, $01, $7B, $20, $00]), Fd(17),
+        BLit([$22, $01]), Fd(27), BLit([$00, $20, $01]), Fd(27),
+        BLit([$00, $6A, $0B])]))
     ]))
   ]);
 end;
@@ -3486,6 +3492,11 @@ begin
     stored once in the local rather than round-tripping through a temp slot. }
   Expect<Integer>(Length(Code)).ToBe(176);
   Expect<UInt32>(RegisterCount).ToBe(FIr.Functions[2].RegisterCount);
+  Code := JitStageFunctionBytes(FStore, @FIr.Functions[4], EntryOffset,
+    RegisterCount);
+  { The producer temporary remains live after local.tee, so this function
+    must retain its move instead of applying the single-use fusion. }
+  Expect<Integer>(Length(Code)).ToBe(180);
   {$ELSE}
   Expect<Boolean>(True).ToBe(True);
   {$ENDIF}
@@ -3505,6 +3516,10 @@ begin
     [MakeValueI32($12345678)])).ToBe(VEC_COMPILED);
   Expect<Boolean>(DiffModule(SimdLocalsModuleBytes, 'move2',
     [MakeValueI32($76543210)])).ToBe(VEC_COMPILED);
+  { Separate stores matter here: running the interpreter first in the JIT
+    store could leave the otherwise unwritten temporary looking valid. }
+  Expect<Boolean>(DiffFresh(SimdLocalsModuleBytes, 'tee_both',
+    [MakeValueI32(37)])).ToBe(VEC_COMPILED);
 end;
 
 procedure TJitTests.TestSimdFloatNanPminRelaxed;

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -1034,6 +1034,46 @@ begin
   ]);
 end;
 
+{ A reference array store followed by a forced collection. The stored struct
+  is reachable only through the array when the second struct.new collects, so
+  the final field read proves the native store is visible to precise tracing.
+  The second export pins array.set's null-before-bounds trap order. }
+function GcRefArrayModuleBytes: TWasmBytes;
+begin
+  Result := Cat([
+    BLit(WASM_HEADER),
+    Sect(1, VecOf([
+      BLit([$5F, $01, $7F, $01]),                    { 0: struct (mut i32) }
+      BLit([$5E, $63, $00, $01]),                    { 1: array (mut ref null 0) }
+      BLit([$60, $00, $01, $7F])])),                 { 2: ()->i32 }
+    Sect(3, VecOf([BLit([$02]), BLit([$02]), BLit([$02])])),
+    Sect(7, VecOf([
+      ExportEntry('visible', $00, 0),
+      ExportEntry('nullset', $00, 1),
+      ExportEntry('dirty', $00, 2)])),
+    Sect(10, VecOf([
+      CodeEntry([
+        $01, $01, $63, $01,                          { local (ref null 1) }
+        $41, $01, $FB, $07, $01, $21, $00,           { array.new_default 1 }
+        $20, $00, $41, $00, $41, $FB, $00,           { array, index 0, 123 }
+        $FB, $00, $00, $FB, $0E, $01,                { struct.new; array.set }
+        $41, $E7, $07, $FB, $00, $00, $1A,           { allocate/drop struct(999) }
+        $20, $00, $41, $00, $FB, $0B, $01,           { array.get 1 }
+        $FB, $02, $00, $00, $0B]),                   { struct.get 0 0 }
+      CodeEntry([
+        $00, $D0, $01, $41, $FF, $01, $41, $00,      { null, index 255, value }
+        $FB, $00, $00, $FB, $0E, $01,                { struct.new; array.set }
+        $41, $00, $0B]),
+      CodeEntry([
+        $02, $01, $63, $01, $01, $7F,                { ref-array + i32 locals }
+        $41, $01, $FB, $07, $01, $21, $00,           { array.new_default 1 }
+        $41, $4D, $21, $01,                           { dirty local := 77 }
+        $20, $00, $41, $00, $FB, $0B, $01, $1A,      { array.get; drop }
+        $20, $01, $0B])                               { dirty local remains 77 }
+    ]))
+  ]);
+end;
+
 { i31: ref.i31 then i31.get_s / i31.get_u (31-bit sign vs zero extension), and
   i31.get_s on a null (a 'null i31 reference' trap). }
 function I31ModuleBytes: TWasmBytes;
@@ -1500,6 +1540,7 @@ type
     procedure TestStructRoundTrip;
     procedure TestArrayRoundTrip;
     procedure TestArrayOobTrap;
+    procedure TestReferenceArrayStoreGcVisibility;
     procedure TestI31;
     procedure TestGcMidBodyCollectionWalkable;
     procedure TestGcInlineAllocFreeListReuse;
@@ -3344,6 +3385,17 @@ begin
     [MakeValueI32(9)])).ToBe('out of bounds array access');
 end;
 
+procedure TJitTests.TestReferenceArrayStoreGcVisibility;
+begin
+  FDiffThreshold := 0;
+  Expect<Boolean>(DiffFresh(GcRefArrayModuleBytes, 'visible', []))
+    .ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
+  Expect<string>(TrapMessageOf(GcRefArrayModuleBytes, 'nullset', []))
+    .ToBe('null array reference');
+  Expect<Boolean>(DiffFresh(GcRefArrayModuleBytes, 'dirty', []))
+    .ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
+end;
+
 procedure TJitTests.TestI31;
 begin
   { i31.get_s sign-extends the 31-bit payload; get_u zero-extends. }
@@ -3589,6 +3641,8 @@ begin
     TestStructRoundTrip);
   Test('array new/get/len incl. packed extension match', TestArrayRoundTrip);
   Test('out-of-bounds array access traps identically', TestArrayOobTrap);
+  Test('reference array stores stay visible to GC and trap null first',
+    TestReferenceArrayStoreGcVisibility);
   Test('i31 ref/get_s/get_u and null trap match', TestI31);
   Test('a mid-body collection keeps a live ref (compiled frame is GC-walkable)',
     TestGcMidBodyCollectionWalkable);

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -1547,6 +1547,7 @@ type
 
     { --- Wave 6: v128 SIMD via the Wasm.Interp.Vector leaves --------- }
     procedure TestSimdCompute;
+    procedure TestSimdLocalResultFusionCodeShape;
     procedure TestSimdLocalsMoveConst;
     procedure TestSimdFloatNanPminRelaxed;
     procedure TestSimdMemory;
@@ -3460,6 +3461,36 @@ begin
     [])).ToBe(VEC_COMPILED);
 end;
 
+procedure TJitTests.TestSimdLocalResultFusionCodeShape;
+{$IFDEF WASM_JIT_ARM64}
+var
+  Code: TWasmBytes;
+  EntryOffset: NativeUInt;
+  RegisterCount: UInt32;
+{$ENDIF}
+begin
+  {$IFDEF WASM_JIT_ARM64}
+  FBytes := SimdLocalsModuleBytes;
+  DecodeModule(FBytes, FModule);
+  FIr := ValidateModule(FModule, FBytes);
+  Code := JitStageFunctionBytes(FStore, @FIr.Functions[0], EntryOffset,
+    RegisterCount);
+  { v128.const writes the visible local directly: the following move.v128
+    keeps its label but emits no redundant Q-register load/store pair. }
+  Expect<Integer>(Length(Code)).ToBe(148);
+  Expect<NativeUInt>(EntryOffset).ToBe(0);
+  Expect<UInt32>(RegisterCount).ToBe(FIr.Functions[0].RegisterCount);
+  Code := JitStageFunctionBytes(FStore, @FIr.Functions[2], EntryOffset,
+    RegisterCount);
+  { The same peephole applies when a native splat produces Q0: its result is
+    stored once in the local rather than round-tripping through a temp slot. }
+  Expect<Integer>(Length(Code)).ToBe(176);
+  Expect<UInt32>(RegisterCount).ToBe(FIr.Functions[2].RegisterCount);
+  {$ELSE}
+  Expect<Boolean>(True).ToBe(True);
+  {$ENDIF}
+end;
+
 procedure TJitTests.TestSimdLocalsMoveConst;
 begin
   { v128.const and v128 local.set/get/tee are lowered natively by both
@@ -3651,6 +3682,8 @@ begin
 
   Test('v128 const/splat/extract/replace/add/eq/shuffle/swizzle match',
     TestSimdCompute);
+  Test('native v128 results bypass an adjacent lowering move',
+    TestSimdLocalResultFusionCodeShape);
   Test('v128 consts and local set/get/tee move natively and match',
     TestSimdLocalsMoveConst);
   Test('v128 NaN canonicalisation, pmin/pmax, and a relaxed op match per lane',

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -584,6 +584,25 @@ var
     SetLength(SkipPlanned, Length(AFn^.Code));
     for K := 0 to High(AFn^.Code) do
       PlannedCode[K] := AFn^.Code[K];
+    {$IFDEF WASM_JIT_ARM64}
+    for K := 1 to High(PlannedCode) do
+      if (PlannedCode[K].Op = iroMoveVec) and
+        Arm64NativeVecOp(PlannedCode[K - 1].Op) and
+        (PlannedCode[K - 1].Dest = PlannedCode[K].A) and
+        (PlannedCode[K - 1].Dest < UInt32(Length(AFn^.RegTypes))) and
+        (AFn^.RegTypes[PlannedCode[K - 1].Dest].Kind = wvkVec) and
+        not IsVisibleFrameReg(PlannedCode[K - 1].Dest) and
+        IsVisibleFrameReg(PlannedCode[K].Dest) and
+        not Targets[K - 1] and not Targets[K] then
+      begin
+        { A validated expression result is consumed by the immediately
+          following lowering move. Store the native Q result in the move's
+          canonical local/result slot directly; both IR labels remain bound at
+          the same fallthrough point and no vector state crosses an edge. }
+        PlannedCode[K - 1].Dest := PlannedCode[K].Dest;
+        SkipPlanned[K] := True;
+      end;
+    {$ENDIF}
     if not UseStaticCache then
       Exit;
     for K := 1 to High(PlannedCode) do

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -1495,11 +1495,10 @@ var
     end;
   end;
 
-  { Numeric struct.get/get_s/get_u/set bake their field offset instead of
-    paying a helper crossing that re-resolves the layout per access. The
-    offset mirrors TWasmGcTypes' layout math exactly (header, per-field
-    align-up to storage width, cumulative advance); ref fields stay on the
-    helper path because stores need the write barrier. }
+  { Fixed-type struct and array access bake their field shape instead of
+    paying a helper crossing that re-resolves the layout per access. Struct
+    offsets mirror TWasmGcTypes' layout math; arrays have a fixed 16-byte
+    element base and a statically known element width. }
   procedure AnalyzeGcFieldAccess;
   var
     K, F, CanonIdx: Integer;
@@ -1589,6 +1588,37 @@ var
         (Ord(AFn^.Code[K].Op = iroStructGetS) shl 1) or
         (UInt64(Width) shl 8) or
         (UInt64(Offset) shl 16);
+    end;
+
+    for K := 0 to High(AFn^.Code) do
+    begin
+      if not (AFn^.Code[K].Op in [iroArrayGet, iroArrayGetS,
+        iroArrayGetU, iroArraySet]) then
+        Continue;
+      TargetIdx := UInt32(AFn^.Code[K].Imm);
+      if (TargetIdx >= UInt32(Length(AIr.TypeIndexToCanon))) then
+        Continue;
+      CanonIdx := Integer(AIr.TypeIndexToCanon[TargetIdx]);
+      if (CanonIdx < 0) or (CanonIdx >= Length(AIr.CanonTypes)) then
+        Continue;
+      Comp := @AIr.CanonTypes[CanonIdx].Comp;
+      if Comp^.Kind <> wckArray then
+        Continue;
+      Width := StorageWidthOf(Comp^.Arr.Elem.Storage);
+      IsRef := (not Comp^.Arr.Elem.Storage.IsPacked) and
+        (Comp^.Arr.Elem.Storage.ValueType.Kind = wvkRef);
+      IsPacked := Comp^.Arr.Elem.Storage.IsPacked;
+      if (Width > 8) or
+        ((AFn^.Code[K].Op = iroArrayGet) and IsPacked) or
+        ((AFn^.Code[K].Op in [iroArrayGetS, iroArrayGetU]) and
+          not IsPacked) then
+        Continue;
+      { bit0 native | bit1 signed | bit2 array | bit3 reference |
+        bits8-15 width | bits16-31 element-zero offset }
+      GcShapes[K] := 1 or
+        (Ord(AFn^.Code[K].Op = iroArrayGetS) shl 1) or 4 or
+        (Ord(IsRef) shl 3) or (UInt64(Width) shl 8) or
+        (UInt64(WASM_ARRAY_ELEMS_OFFSET) shl 16);
     end;
   end;
 

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -561,6 +561,41 @@ var
       end;
   end;
 
+  function VectorUseCount(const AReg: UInt32): UInt32;
+  var
+    Info: TWasmIrOpInfo;
+    K, N: Integer;
+
+    procedure CountIfSame(const ASource: UInt32);
+    begin
+      if ASource = AReg then
+        Inc(Result);
+    end;
+
+  begin
+    Result := 0;
+    for K := 0 to High(AFn^.Code) do
+    begin
+      Info := IR_OP_INFO[AFn^.Code[K].Op];
+      if Info.DestKind = ifkSrcReg then
+        CountIfSame(AFn^.Code[K].Dest);
+      if Info.AKind = ifkSrcReg then
+        CountIfSame(AFn^.Code[K].A)
+      else if Info.AKind = ifkAuxIndex then
+        { Every A aux block is a source-register list. B aux blocks carry
+          call results or control targets; Imm aux blocks carry literals,
+          masks, or memory arguments. }
+        for N := 0 to Integer(IrAuxBlockCount(AFn^.AuxU32,
+          AFn^.Code[K].A)) - 1 do
+          CountIfSame(IrAuxBlockItem(AFn^.AuxU32, AFn^.Code[K].A,
+            UInt32(N)));
+      if Info.BKind = ifkSrcReg then
+        CountIfSame(AFn^.Code[K].B);
+      if Info.ImmKind in [ifkSrcReg, ifkSrcRegImm] then
+        CountIfSame(UInt32(AFn^.Code[K].Imm));
+    end;
+  end;
+
   function IsVisibleFrameReg(const AReg: UInt32): Boolean; forward;
 
   function NativeScalarLeafTarget(const AFuncIdx: UInt32): Boolean;
@@ -591,6 +626,7 @@ var
         (PlannedCode[K - 1].Dest = PlannedCode[K].A) and
         (PlannedCode[K - 1].Dest < UInt32(Length(AFn^.RegTypes))) and
         (AFn^.RegTypes[PlannedCode[K - 1].Dest].Kind = wvkVec) and
+        (VectorUseCount(PlannedCode[K - 1].Dest) = 1) and
         not IsVisibleFrameReg(PlannedCode[K - 1].Dest) and
         IsVisibleFrameReg(PlannedCode[K].Dest) and
         not Targets[K - 1] and not Targets[K] then


### PR DESCRIPTION
## Summary

Waves 12 and 13 of the benchmark-gated Wasmtime-gap series accelerate two
Arm64 JIT/AOT hot paths while preserving the shared validated IR, canonical
register state, safepoints, trap ordering, and interpreter/JIT/AOT identity.

- Fixed-type scalar `array.get`, `array.get_s`, `array.get_u`, and `array.set`
  now use a driver-proven native Arm64 path. The driver bakes the validated
  element width, signedness, reference shape, and element offset; generated
  code preserves null, object-kind, and unsigned-bounds checks in the existing
  order before a scaled load or store. Unsupported shapes retain the runtime
  helper path. Reference stores are direct only under the current stop-the-world
  collector's deliberately empty write barrier; the emitter comment requires
  those shapes to decline or gain a PIC helper if that policy changes.
- A native v128 producer immediately followed by `iroMoveVec` into a visible
  local/result slot now writes that canonical slot directly when an
  `IR_OP_INFO`-driven source scan proves the temporary has exactly one use.
  Nothing is cached across an instruction or control-flow boundary.

Two correctness defects were caught by independent review and fixed before
delivery. Native array gets originally invalidated unrelated dirty cached
locals; the final path uses the cache-aware store operation. The initial SIMD
peephole mishandled `local.tee`, whose producer temporary remains live after
the local write; a fresh-store differential reproduced that failure, and the
single-use proof now keeps the move for multi-use temporaries.

Serialized release B-C-C-B measurements on Apple M5 Max, one warm-up discarded
and seven samples per leg:

- GC/array path: 43.551 -> 24.925 -> 24.182 -> 43.631 ms
  (**-42.77%/-44.57%**). Candidate/Wasmtime was approximately 0.90-0.92x.
- SIMD: 8.602 -> 5.742 -> 5.827 -> 8.809 ms
  (**-33.25%/-33.85%**). Candidate/Wasmtime improved to 1.189x/1.176x.
- The integrated full schedule measured GC at 24.572 ms versus Wasmtime
  26.887 ms, and SIMD at 5.412 ms versus Wasmtime 4.450 ms.

Rejected direct-call and memory-load experiments were fully reverted after
flat or noisy measurements; their evidence remains in `.agent/HANDOFF.md`.

## Testing

- `lwpt install --frozen`
- `lwpt format --check` (91 files)
- `lwpt build` and `lwpt build --mode release` (3/3 applications)
- `lwpt test` (44/44 programs)
- `lwpt agents --check`
- `npx markdownlint-cli2 "**/*.md"` (44 files, 0 issues)
- `git diff --check`
- Recursive pinned corpus byte-identical across interpreter/JIT/AOT:
  files=288, errors=0, pass=65851, fail=368, skip=904, staged=0;
  JIT/AOT compiled=8799.

Focused differentials cover collection after a reference-array store,
null-before-bounds ordering, unrelated dirty-cache liveness across native
`array.get`, safe SIMD code shapes, and the multi-use `local.tee` exclusion.
The generated-code changes are Arm64-gated; the x86-64 and interpreter-only
platform proofs are delegated to exact-head CI.

## Linked issues

None — this continues the measured optimization series recorded in
`.agent/HANDOFF.md`.
