### PR TITLE
perf(jit): emit numeric struct fields natively on x64

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,84 @@
 # Handoff
 
-Updated: 2026-08-23 (Wave 13 Arm64 adjacent-vector-result fusion accepted)
+Updated: 2026-08-23 (Wave 14 x64 numeric struct-field access accepted)
+
+## Wave 14 — numeric fixed-struct field access natively on x64 ACCEPTED
+
+- Started from freshly fetched `origin/main@e7ee03be80ad713c4061308c224bb096a1df2e72`
+  (merged PR #20) in clean branch `t3code/optimize-runtime-wave14`. The single
+  accepted commit is `2e33b67fc8cef4d5baa7b7192d8f07f613bf129a`
+  (`perf(jit): emit numeric struct fields natively on x64`), local and
+  unpushed. The integration was an exact fast-forward to that measured lane
+  commit, so no post-measurement source combination was introduced.
+- Fresh exact-main macOS/Arm64 best/AOT baseline (one warm-up, seven rotated
+  samples) left direct call as the sole goal miss: 144.659 ms versus Wasmtime
+  59.792 ms (2.42x). The remaining ratios were startup 0.64x, loop 1.04x,
+  fib 0.93x, memory 1.17x, memory-load 1.14x, memory-store 1.41x,
+  memory-grow 0.99x, gc 0.93x, SIMD 1.29x, and host-call 0.90x. Raw evidence
+  is `/tmp/wasmlight-wave14-baseline-e7ee03b.json`.
+- A five-second `sample(1)` profile of a self-checking 30x scaled call module
+  put all 3,875 samples in generated code. Two different bounded Arm64 call
+  experiments were therefore measured and REJECTED: (1) omitting zero MOVK
+  halves shortened the hot function from 269 to 242 instructions but
+  regressed B-C-C-B by 38.67% forward / 63.02% reverse (raw
+  `/tmp/w14-imm-{base1,cand1,cand2,base2}.json`); (2) rescheduling independent
+  cap loads was flat/noisy at -0.08% with fully overlapping ranges (raw
+  `/tmp/w14-call-{base1,cand1,cand2,base2}.json`). Both worktrees were fully
+  reverted and remain clean with no commits. Do not retry activation-wide
+  hoisting, per-instance call tables, scaled-LDR-only, zero-MOVK omission, or
+  this cap-load scheduling shape without new evidence.
+- The accepted x64 mechanism reuses the driver's validated per-instruction GC
+  shape analysis. Eligible numeric `struct.get`, `struct.get_s`,
+  `struct.get_u`, and `struct.set` sites receive only a validated width,
+  signedness, and byte offset. The x64 emitter performs the cached reference
+  load and null-structure trap before a direct canonical scalar load or
+  truncating store. Numeric stores require no write barrier; reference/vector
+  fields, arrays, and ineligible shapes retain the unchanged generic helper.
+  No runtime address is baked, and allocation, GC, safepoints, barriers, and
+  AOT PIC/fingerprint contracts are unchanged. Differential tests pin signed
+  and unsigned packed loads, read/write round trips, exact null-trap order,
+  and an unrelated cached local surviving the access; x64 byte-shape tests
+  pin direct load/store emission and absence of runtime dispatch.
+- Linux/x86-64 profiling ran in OrbStack 7.0.14, explicitly virtualized amd64
+  over Arm. `perf_event_open` is unavailable there (`ENOSYS`), so no sampling
+  claim was made. A controlled exact-release self-checking profile instead
+  measured 20 million fixed-field accesses at 3,032.418 ms versus a matched
+  numeric control at 193.271 ms (15.69x, about 142 ns/helper crossing). The
+  first VM preparation under `/tmp` was discarded after stop/start erased the
+  VM tmpfs; all accepted source, binaries, raw data, and gates were rebuilt
+  durably under `/home/jstein/w14-x64-field` with checksum-verified LWPT 0.6.0.
+- Exact retained binary B-C-C-B (one warm-up, seven samples per leg under the
+  persistent flock gate) improved the standard GC workload
+  **1265.464 -> 908.161 -> 915.298 -> 1267.813 ms**, -28.23% forward and
+  -27.80% reverse, with candidate maxima below baseline minima. Raw files are
+  `/home/jstein/w14-x64-field/measurement/gc-{base1,cand1,cand2,base2}.json`.
+  The isolated 20M field workload measured
+  **3046.743 -> 219.657 -> 220.406 -> 2966.666 ms**, -92.79%/-92.57%, with
+  all legs self-checking and disjoint. Raw files use the corresponding
+  `measurement/field-*` names.
+- The complete x64 best-profile 11-workload guard pair measured GC at
+  1032.180 -> 703.613 ms (-31.83%); loop, fib, memory, load, store, and call
+  overlapped and stayed within +/-1.82%, while several other paths improved.
+  Startup's apparent +6.449 ms was classified as noise by its own B-C-C-B
+  (45.600, 47.478, 44.627, 47.516 ms): forward +4.12%, reverse -6.08%, all
+  ranges overlapping. Guard raw files are `measurement/guards-{base,candidate}.raw.json`
+  and `measurement/startup-{base1,cand1,cand2,base2}.json` in the durable VM
+  evidence directory. Both OrbStack VMs were restored to running and the
+  persistent timing lock was verified free.
+- Exact accepted x64 gates pass: frozen install; format 91/91; agents check;
+  dev and release build 3/3; all 44 test programs (focused JIT 68/68 and x64
+  26/26); pinned core corpus byte-identical across interpreter/JIT/AOT at
+  files=257 pass=65188 fail=0 skip=0 staged=0, with 8704 compiled functions in
+  JIT/AOT. Independent exact integration gates on macOS/Arm64 pass frozen
+  install, format, agents check, diff check, Markdown lint, dev/release 3/3,
+  all 44 tests, and the same 65,188/0/0 core tally in every tier (8703 compiled
+  in JIT/AOT). The recursive 288-file diagnostic also reproduces the documented
+  65851/368/904/0 proposal-and-legacy residue tally.
+- Next x64 optimization candidates, only after a fresh baseline/profile, are
+  the already accepted Arm64 fixed-array access mirror and then allocation.
+  On Arm64, direct calls remain the only current 1.43x goal miss, but the two
+  new rejected mechanisms above remove the obvious small instruction-selection
+  variations from consideration.
 
 ## Wave 13 — adjacent Arm64 vector-result moves fused ACCEPTED
 

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -953,12 +953,15 @@ begin
       BLit([$5F, $01, $7F, $01]),                    { 0: struct (mut i32) }
       BLit([$5F, $01, $78, $01]),                    { 1: struct (mut i8) }
       BLit([$60, $01, $7F, $01, $7F])])),            { 2: (i32)->i32 }
-    Sect(3, VecOf([BLit([$02]), BLit([$02]), BLit([$02]), BLit([$02])])),
+    Sect(3, VecOf([BLit([$02]), BLit([$02]), BLit([$02]), BLit([$02]),
+      BLit([$02]), BLit([$02])])),
     Sect(7, VecOf([
       ExportEntry('rt', $00, 0),
       ExportEntry('gets', $00, 1),
       ExportEntry('getu', $00, 2),
-      ExportEntry('setget', $00, 3)])),
+      ExportEntry('setget', $00, 3),
+      ExportEntry('nullget', $00, 4),
+      ExportEntry('dirty', $00, 5)])),
     Sect(10, VecOf([
       CodeEntry([$00, $20, $00, $FB, $00, $00, $FB, $02, $00, $00, $0B]),
       CodeEntry([$00, $20, $00, $FB, $00, $01, $FB, $03, $01, $00, $0B]),
@@ -966,7 +969,14 @@ begin
       CodeEntry([$01, $01, $63, $00,                  { local (ref null 0) }
         $FB, $01, $00, $21, $01,                      { new_default; local.set1 }
         $20, $01, $20, $00, $FB, $05, $00, $00,       { struct.set 0 0 = arg0 }
-        $20, $01, $FB, $02, $00, $00, $0B])]))        { struct.get 0 0 }
+        $20, $01, $FB, $02, $00, $00, $0B]),          { struct.get 0 0 }
+      CodeEntry([$00, $D0, $00, $FB, $02, $00, $00, $0B]),
+      CodeEntry([$02, $01, $7F, $01, $63, $00,         { i32, ref null 0 }
+        $FB, $01, $00, $21, $02,                      { new_default; ref local }
+        $41, $2A, $21, $01,                            { dirty local := 42 }
+        $20, $02, $20, $00, $FB, $05, $00, $00,       { struct.set arg0 }
+        $20, $02, $FB, $02, $00, $00, $1A,            { struct.get; drop }
+        $20, $01, $0B])]))                             { dirty local survives }
   ]);
 end;
 
@@ -3371,7 +3381,12 @@ begin
     [MakeValueI32($FF)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
   { struct.set (barriered) then read back. }
   Expect<Boolean>(DiffFresh(GcStructModuleBytes, 'setget',
-    [MakeValueI32(777)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF})
+    [MakeValueI32(777)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
+  DiffFresh(GcStructModuleBytes, 'nullget', [MakeValueI32(0)]);
+  Expect<string>(TrapMessageOf(GcStructModuleBytes, 'nullget',
+    [MakeValueI32(0)])).ToBe('null structure reference');
+  Expect<Boolean>(DiffFresh(GcStructModuleBytes, 'dirty',
+    [MakeValueI32(123)])).ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF})
 end;
 
 procedure TJitTests.TestArrayRoundTrip;

--- a/source/units/Wasm.Jit.X64.Test.pas
+++ b/source/units/Wasm.Jit.X64.Test.pas
@@ -65,6 +65,7 @@ type
     procedure TestPredicateDeclinesEh;
     procedure TestCallArityFence;
     procedure TestStaticCacheKeepsShiftResult;
+    procedure TestGcFieldAccessBytes;
 
     procedure TestExecPlaceholder;
   end;
@@ -631,6 +632,65 @@ begin
   end;
 end;
 
+procedure TX64Tests.TestGcFieldAccessBytes;
+var
+  Buf: TWasmCodeBuffer;
+  Cache: TX64RegCache;
+
+  function HasSeq(const AExpected: array of Byte): Boolean;
+  var
+    I, J: Integer;
+  begin
+    for I := 0 to Buf.Size - Length(AExpected) do
+    begin
+      Result := True;
+      for J := 0 to High(AExpected) do
+        if Buf.ByteAt(I + J) <> AExpected[J] then
+        begin
+          Result := False;
+          Break;
+        end;
+      if Result then
+        Exit;
+    end;
+    Result := False;
+  end;
+
+begin
+  { get_s i8 at offset 24: direct MOVSX from the baked address, with the null
+    trap retained and no generic runtime dispatch call. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64InitRegCache(Cache);
+    X64EmitGcFieldAccess(Buf,
+      MakeIrInstr(iroStructGetS, 2, 1, 0, 0),
+      1 or 2 or (UInt64(1) shl 8) or (UInt64(24) shl 16), Cache);
+    X64ResolvePatches(Buf);
+    Expect<Boolean>(HasSeq([$48, $8D, $40, $18, $0F, $BE, $00]))
+      .ToBe(True);
+    Expect<Boolean>(HasSeq([$41, $FF, $57,
+      Byte(Ord(aohRtDispatch) * 8)])).ToBe(False);
+  finally
+    Buf.Free;
+  end;
+
+  { struct.set i32 at offset 8 stores the low 32 bits directly. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64InitRegCache(Cache);
+    X64EmitGcFieldAccess(Buf,
+      MakeIrInstr(iroStructSet, 0, 1, 2, 0),
+      1 or (UInt64(4) shl 8) or (UInt64(8) shl 16), Cache);
+    X64ResolvePatches(Buf);
+    Expect<Boolean>(HasSeq([$48, $8D, $40, $08])).ToBe(True);
+    Expect<Boolean>(HasSeq([$89, $08])).ToBe(True);
+    Expect<Boolean>(HasSeq([$41, $FF, $57,
+      Byte(Ord(aohRtDispatch) * 8)])).ToBe(False);
+  finally
+    Buf.Free;
+  end;
+end;
+
 procedure TX64Tests.TestSlotOffset;
 begin
   Expect<UInt32>(X64SlotByteOffset(0)).ToBe(0);
@@ -726,6 +786,8 @@ begin
   Test('the call-site arity fence admits a zero-slot call', TestCallArityFence);
   Test('static allocation keeps a shifted expression result',
     TestStaticCacheKeepsShiftResult);
+  Test('numeric GC fields use baked native x64 loads and stores',
+    TestGcFieldAccessBytes);
   Test('executable proof is gated to a real x86-64 host', TestExecPlaceholder);
 end;
 

--- a/source/units/Wasm.Jit.X64.pas
+++ b/source/units/Wasm.Jit.X64.pas
@@ -115,6 +115,11 @@ type
     FixedWriteThrough: Boolean;
   end;
 
+  { Per-instruction native-shape words handed over by the driver's
+    AnalyzeGcFieldAccess; indexed by IR instruction index. }
+  TX64GcShapeArray = array[0..$FFFFFF] of UInt64;
+  PX64GcShapeArray = ^TX64GcShapeArray;
+
 const
   { --- x86-64 register numbers (SDM Vol. 2 Table 2-2) --------------------- }
   X64_RAX = 0;
@@ -385,7 +390,13 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
   const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
   const ARetainContext, AUseNativeScalarCall: Boolean;
-  var ACache: TX64RegCache): Boolean; overload;
+  var ACache: TX64RegCache;
+  const AGcShapes: PX64GcShapeArray): Boolean; overload;
+{ Numeric struct field access with a validated baked byte offset. Null refs
+  trap before the load; reference and vector fields never receive a shape. }
+procedure X64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AShape: UInt64;
+  var ACache: TX64RegCache);
 procedure X64EmitCompareBranchCached(const ABuf: TWasmCodeBuffer;
   const ACompare, ABranch: TWasmIrInstr; var ACache: TX64RegCache);
 function X64CanEmitInstr(const AIns: TWasmIrInstr;
@@ -417,6 +428,11 @@ uses
 procedure X64EmitScalarMemory(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAddr64,
   AUsePinnedMemory: Boolean); forward;
+procedure X64EmitLoadScalar(const ABuf: TWasmCodeBuffer;
+  const ADest, ABase: Byte; const ASize: UInt32; const ASigned,
+  AResult64: Boolean); forward;
+procedure X64EmitStoreScalar(const ABuf: TWasmCodeBuffer;
+  const ASource, ABase: Byte; const ASize: UInt32); forward;
 
 procedure X64CachedLoad(const ABuf: TWasmCodeBuffer; var ACache: TX64RegCache;
   const ADest: Byte; const ASlot: UInt32); forward;
@@ -521,7 +537,44 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
 begin
   Result := X64EmitOpCached(ABuf, AIns, AAux, AInsIndex, AAddr64,
     AUsePinnedMemory, False, False, 0, 0, 0, -1, -1, False, False,
-    ACache);
+    ACache, nil);
+end;
+
+procedure X64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AShape: UInt64;
+  var ACache: TX64RegCache);
+var
+  Offset, Width: UInt32;
+  Signed: Boolean;
+  GoodLabel: TWasmJitLabel;
+begin
+  Offset := UInt32(AShape shr 16);
+  Width := UInt32((AShape shr 8) and $FF);
+  Signed := (AShape and 2) <> 0;
+
+  X64CachedLoad(ABuf, ACache, X64_RAX, AIns.A);
+  X64EmitAluRegReg(ABuf, $85, True, X64_RAX, X64_RAX);
+  GoodLabel := ABuf.NewLabel;
+  X64EmitJccTo(ABuf, X64_CC_NE, UInt32(GoodLabel));
+  X64EmitMovRegImm32(ABuf, X64_ARG0,
+    UInt32(Ord(wtkNullStructReference)));
+  X64EmitCallHelper(ABuf, aohTrapKind);
+  ABuf.BindLabel(GoodLabel);
+
+  X64EmitLea(ABuf, X64_RAX, X64_RAX, Int32(Offset));
+  case AIns.Op of
+    iroStructGet, iroStructGetS, iroStructGetU:
+      begin
+        X64EmitLoadScalar(ABuf, X64_RAX, X64_RAX, Width, Signed,
+          Width = 8);
+        X64CachedStore(ABuf, ACache, X64_RAX, AIns.Dest);
+      end;
+    iroStructSet:
+      begin
+        X64CachedLoad(ABuf, ACache, X64_RCX, AIns.B);
+        X64EmitStoreScalar(ABuf, X64_RCX, X64_RAX, Width);
+      end;
+  end;
 end;
 
 function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
@@ -531,13 +584,21 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const ANativeRegisterCount, ANativeParamReg, ANativeResultReg: UInt32;
   const ANativeCoreLabel, ANativeExhaustedLabel: TWasmJitLabel;
   const ARetainContext, AUseNativeScalarCall: Boolean;
-  var ACache: TX64RegCache): Boolean;
+  var ACache: TX64RegCache;
+  const AGcShapes: PX64GcShapeArray): Boolean;
 begin
   Result := True;
   if X64ScalarMemoryOp(AIns.Op) then
   begin
     X64InvalidateRegCache(ACache);
     X64EmitScalarMemory(ABuf, AIns, AAddr64, AUsePinnedMemory);
+    Exit;
+  end;
+  if (AGcShapes <> nil) and
+    ((AGcShapes[AInsIndex] and 1) <> 0) and
+    ((AGcShapes[AInsIndex] and 4) = 0) then
+  begin
+    X64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
     Exit;
   end;
   case AIns.Op of

--- a/source/units/Wasm.Jit.pas
+++ b/source/units/Wasm.Jit.pas
@@ -1985,8 +1985,8 @@ begin
     { After fusion planning, so already-folded constants are not offered a
       host register their defining instruction would never have used. }
     AnalyzeConstSlots;
-    {$IFDEF WASM_JIT_ARM64}
     AnalyzeGcFieldAccess;
+    {$IFDEF WASM_JIT_ARM64}
     AnalyzeGcInlineAlloc;
     {$ENDIF}
     {$IFDEF WASM_JIT_ARM64}
@@ -2143,7 +2143,7 @@ begin
           AFn^.RegisterCount, NativeParamReg, NativeResultReg,
           NativeCoreLabel, NativeExhaustedLabel, UseX64ExtendedFrame,
           NativeScalarCall,
-          X64Cache);
+          X64Cache, @GcShapes[0]);
       {$ENDIF}
       if not Emitted then
         { The predicate guaranteed every op is emittable; reaching here is an


### PR DESCRIPTION
## Summary

Wave 14 of the benchmark-gated runtime optimization series removes the generic
runtime-helper crossing for eligible numeric fixed-struct field access in the
x64 JIT/AOT backend.

- The shared JIT driver now runs its existing validated GC-field-shape analysis
  for x64 and passes each instruction's proven width, signedness, and byte
  offset into the backend.
- Eligible `struct.get`, `struct.get_s`, `struct.get_u`, and `struct.set` sites
  perform the cached reference load and null-structure trap before a direct
  canonical scalar load or truncating store. Reference/vector fields, arrays,
  and every ineligible shape retain the unchanged generic helper path.
- Numeric stores require no write barrier. The change bakes no runtime address
  and does not alter allocation, collection, safepoints, stack maps, barriers,
  AOT PIC, or the artifact fingerprint.

Measured in Linux 7.0.14/x86-64 under OrbStack, explicitly virtualized amd64
over Arm, using exact release binaries, one discarded warm-up, seven samples
per leg, and serialized B-C-C-B ordering:

- Standard GC workload: 1265.464 -> 908.161 -> 915.298 -> 1267.813 ms
  (**-28.23% forward / -27.80% reverse**), with candidate ranges fully below
  baseline ranges.
- Isolated self-checking 20M field workload:
  3046.743 -> 219.657 -> 220.406 -> 2966.666 ms
  (**-92.79% / -92.57%**).
- Full guard matrix: GC improved 31.83%; unrelated substantial workloads
  overlapped and stayed within +/-1.82% or improved. A startup-only B-C-C-B
  reversed its apparent movement with fully overlapping ranges and classified
  it as noise.

Two Arm64 direct-call experiments were also measured and fully reverted: a
shorter immediate materialization regressed both orders, while independent cap
load scheduling was flat within noise. Their evidence and the accepted raw
measurement paths are recorded in `.agent/HANDOFF.md`.

## Testing

- `lwpt install --frozen`
- `lwpt format --check` (91/91 files)
- `lwpt agents --check`
- `lwpt build` and `lwpt build --mode release` (3/3 applications each)
- `lwpt test` (44/44 programs)
- `npx markdownlint-cli2 "**/*.md"` (0 issues)
- `git diff --check`
- Focused JIT differential tests (68/68) and x64 encoder/code-shape tests
  (26/26) on Linux/x86-64
- Pinned core corpus on Linux/x86-64: interpreter/JIT/AOT each 257 files,
  65,188 pass, 0 fail/skip/staged; JIT/AOT compiled 8,704 functions
- Independent macOS/Arm64 integration gate: 44/44 programs and the same
  65,188/0/0 core tally in every tier; JIT/AOT compiled 8,703 functions

New tests pin signed and unsigned packed loads, numeric read/write round trips,
the exact null trap, preservation of an unrelated cached local, direct x64
load/store bytes, and absence of generic runtime dispatch on eligible shapes.

## Linked issues

None — this continues the measured optimization series recorded in
`.agent/HANDOFF.md`.
