### PR TITLE
docs(skills): prevent invalid runtime benchmark comparisons

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -2,6 +2,24 @@
 
 Updated: 2026-08-23 (Wave 14 x64 numeric struct-field access accepted)
 
+## Runtime optimization skill retro follow-up — adopted
+
+- Resumed the unpublished retro follow-up from local commit `2b9a82d` onto
+  freshly fetched `origin/main@92c2de3` as commit `4869b50` on
+  `t3code/adopt-optimize-runtime`; the original sibling branch was stale and
+  had never published this commit in a pull request.
+- `.agents/skills/optimize-runtime/SKILL.md` now requires release-binary hash
+  verification against the immediate predecessor, a host-load check before
+  each measurement schedule, and mechanism-plus-measurement evidence for every
+  rejected experiment. These are workflow safeguards only; runtime source,
+  benchmark implementations, tier behavior, and architecture contracts are
+  unchanged.
+- The resumed change passed the skill validator in an isolated `uvx` PyYAML
+  environment, frozen install, format, generated-agent check, Markdown lint,
+  development build of all three programs, and all 44 default test programs.
+  No runtime benchmark or spec-corpus rerun applies to this documentation-only
+  workflow change.
+
 ## Wave 14 — numeric fixed-struct field access natively on x64 ACCEPTED
 
 - Started from freshly fetched `origin/main@e7ee03be80ad713c4061308c224bb096a1df2e72`

--- a/.agents/skills/optimize-runtime/SKILL.md
+++ b/.agents/skills/optimize-runtime/SKILL.md
@@ -34,19 +34,28 @@ accept it.
 
 1. Build and retain a baseline binary from the exact starting commit with the
    same compiler, dependencies, flags, and host used for candidates.
-2. Stop competing benchmark processes. Serialize measurements through one
+2. Verify measurement validity before every schedule. Each of these has
+   invalidated whole comparison sets at least once:
+   - rebuild with `--mode release` and confirm the binary hash against the
+     retained predecessor before treating any run as a candidate —
+     development builds are correctness gates, never candidates;
+   - check `ps aux -r` and the load average for external consumers (VMs,
+     browsers, builds) that the shared lock cannot exclude;
+   - diff strictly against the immediate predecessor head's retained binary,
+     not an older wave's.
+3. Stop competing benchmark processes. Serialize measurements through one
    shared exclusive lock, conventionally `/tmp/wasmlight-perf-gate.lock`.
-3. Discard at least one warm-up. Default to seven measured samples and report
+4. Discard at least one warm-up. Default to seven measured samples and report
    the median plus the sample spread. Use fewer only for an expensive workload
    and record why.
-4. Measure the target and representative guards from `wasmbench`: startup,
+5. Measure the target and representative guards from `wasmbench`: startup,
    loop, fib/direct calls, scalar memory, varying-address memory, numeric, and
    SIMD as applicable. Keep iteration counts large enough to escape timer
    quantization.
-5. Record the exact commit, command, OS, architecture, execution tier, workload
+6. Record the exact commit, command, OS, architecture, execution tier, workload
    size, warm-up count, sample count, order, median, spread, and verified
    result.
-6. When comparing Wasmtime, run an identical module and entry point, exclude
+7. When comparing Wasmtime, run an identical module and entry point, exclude
    compilation from both sides, precompile both artifacts, verify observable
    results, and run on the same host. Label emulated or virtualized Linux
    results explicitly rather than presenting them as native hardware.
@@ -103,8 +112,9 @@ implementation, builds, and correctness tests; serialize performance runs.
    the user explicitly accepts that trade-off after seeing both measurements.
 4. Require identical verified results and relevant focused tests before
    integration. Never turn benchmark numbers into test assertions.
-5. Keep rejected work out of the accepted commit. Record why it lost so a later
-   wave does not unknowingly repeat it.
+5. Keep rejected work out of the accepted commit. Record why it lost — the
+   mechanism and the deciding measurements — so a later wave does not
+   unknowingly repeat it.
 
 ## Re-measure combined integration
 


### PR DESCRIPTION
## Summary

- require release-binary hash verification and immediate-predecessor comparisons before benchmark schedules
- require host-load inspection for competing processes outside the shared benchmark lock
- record the mechanism and deciding measurements for rejected experiments
- preserve the resumed retro follow-up in the project handoff

## Testing

- `uvx --with pyyaml python /Users/jstein/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/optimize-runtime`
- `lwpt install --frozen`
- `lwpt format --check`
- `lwpt agents --check`
- `npx markdownlint-cli2 "**/*.md"`
- `lwpt build`
- `lwpt test` (44 passed)

Runtime benchmarks and spec-corpus runs are not applicable because this changes the optimization workflow only, not runtime behavior.

## Linked issues

Follow-up to #3. No issue is closed.