### PR TITLE
fix(ci): restore i386 Windows pre-merge coverage

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -23,8 +23,11 @@ Updated: 2026-08-24 (issue #24 i386 pre-merge repair)
 - Local evidence on macOS/Arm64: frozen install; focused Arm64/JIT suites 2/2;
   format 91/91; generated-agent check; development build 3/3; full tests 44/44;
   `actionlint` clean with the pre-existing SC2005 warning ignored; diff check.
-  Exact i386 compilation, tests, smoke, and interpreter conformance must be
-  reconfirmed by the PR job after the follow-up is pushed.
+- Draft PR #26's follow-up i386 job passed at `f5fe6a3`: build 3/3, all 44
+  tests compiled and passed, CLI positive/negative smoke checks passed, and
+  the pinned interpreter corpus completed with `errors=0`, `pass=65838`, and
+  `staged=0`. The final handoff-only commit still requires exact-head CI before
+  the PR can be marked ready.
 
 Updated: 2026-08-23 (Wave 14 x64 numeric struct-field access accepted)
 

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,24 @@
 # Handoff
 
+Updated: 2026-08-24 (issue #24 i386 pre-merge repair)
+
+## Issue #24 — restore i386-win32 builds and PR coverage
+
+- Started from freshly fetched `origin/main@0553507` in isolated branch
+  `codex/fix-i386-pr-ci`; the pre-existing dirty retrospective worktree was not
+  touched.
+- Replaced the artificial multi-gigabyte `TArm64GcAllocArray` declaration with
+  a typed `^TWasmGcAllocShape` pointer. The unit already enables pointer math,
+  so existing indexed reads retain their behavior without declaring an array
+  the 32-bit compiler cannot represent.
+- Copied the existing `i386-win32` Windows target from post-merge CI into the
+  PR matrix and updated the workflow comment to describe both Windows targets.
+- Local evidence on macOS/Arm64: frozen install; focused Arm64/JIT suites 2/2;
+  format 91/91; generated-agent check; development build 3/3; full tests 44/44;
+  `actionlint` clean with the pre-existing SC2005 warning ignored; diff check.
+  Exact i386 compilation, tests, smoke, and interpreter conformance await the
+  new PR job on the published exact head.
+
 Updated: 2026-08-23 (Wave 14 x64 numeric struct-field access accepted)
 
 ## Runtime optimization skill retro follow-up — adopted

--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -13,11 +13,18 @@ Updated: 2026-08-24 (issue #24 i386 pre-merge repair)
   the 32-bit compiler cannot represent.
 - Copied the existing `i386-win32` Windows target from post-merge CI into the
   PR matrix and updated the workflow comment to describe both Windows targets.
+- Draft PR #26's first i386 run proved the pointer repair: all 44 test programs
+  compiled and the build completed 3/3. It then exposed one runtime-only test
+  defect in `TestInlineStructNewFastPathWords`: the test hard-coded 64-bit host
+  record offsets and reported a misleading final-word expectation after the
+  first mismatch. The test now retains the full hard-pinned 64-bit sequence,
+  derives only host-layout immediate words on `CPU32`, and compares every word
+  directly. No suite or assertion is skipped on i386.
 - Local evidence on macOS/Arm64: frozen install; focused Arm64/JIT suites 2/2;
   format 91/91; generated-agent check; development build 3/3; full tests 44/44;
   `actionlint` clean with the pre-existing SC2005 warning ignored; diff check.
-  Exact i386 compilation, tests, smoke, and interpreter conformance await the
-  new PR job on the published exact head.
+  Exact i386 compilation, tests, smoke, and interpreter conformance must be
+  reconfirmed by the PR job after the follow-up is pushed.
 
 Updated: 2026-08-23 (Wave 14 x64 numeric struct-field access accepted)
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,8 @@ name: PR
 # push to main, so pr.yml is the sole pre-merge signal a PR sees.
 #
 #   pr.yml — every PR: install --frozen + format --check + build + test
-#            on one Linux, one macOS, and one Windows runner. The
-#            Windows leg is here rather than post-merge because the
+#            on one Linux, one macOS, and both Windows targets. The
+#            Windows legs are here rather than post-merge because the
 #            {$IFDEF WINDOWS} paths never compile on the other legs.
 #   ci.yml — push to main only: the full per-arch platform matrix.
 #
@@ -82,6 +82,12 @@ jobs:
             lwpt-archive: zip
             fpc-install: installer
             fpc-win-target: x86_64-win64
+            exe: .exe
+          - runner: windows-latest
+            lwpt-asset: windows-x86
+            lwpt-archive: zip
+            fpc-install: installer
+            fpc-win-target: i386-win32
             exe: .exe
     runs-on: ${{ matrix.runner }}
     defaults:

--- a/source/units/Wasm.Jit.Arm64.Test.pas
+++ b/source/units/Wasm.Jit.Arm64.Test.pas
@@ -32,9 +32,11 @@ uses
 
   TestingPascalLibrary,
   Wasm.Core,
+  Wasm.Interp,
   Wasm.Ir,
   Wasm.Jit.Arm64,
   Wasm.Jit.CodeBuffer,
+  Wasm.Runtime.Gc,
   Wasm.Runtime.Store;
 
 type
@@ -844,7 +846,12 @@ var
   SlowLbl, DoneLbl: TWasmJitLabel;
   I: Integer;
   W: UInt32;
+  ExpectedWords: array[0 .. High(FastPathWords)] of UInt32;
   Words: TWasmBytes;
+  {$IFDEF CPU32}
+  FO: TWasmJitFrameOffsets;
+  GO: TWasmJitGcOffsets;
+  {$ENDIF}
 begin
   Buf := TWasmCodeBuffer.Create;
   try
@@ -865,14 +872,51 @@ begin
     Words := Buf.SnapshotBytes;
     Expect<NativeUInt>(NativeUInt(Length(Words)) div 4)
       .ToBe(NativeUInt(Length(FastPathWords)));
-    W := 0;
+    for I := 0 to High(FastPathWords) do
+      ExpectedWords[I] := FastPathWords[I];
+    {$IFDEF CPU32}
+    { The Arm64 emitter remains portable on interpreter-only 32-bit hosts,
+      where its host-record offsets differ from the executable 64-bit layout.
+      Keep the fixed instruction sequence pinned while deriving only those
+      words whose immediates deliberately describe the host layout. }
+    FO := WasmJitFrameOffsets;
+    GO := WasmJitGcHeapOffsets;
+    ExpectedWords[1] := Arm64LdrX(ARM64_REG_CACHE0, ARM64_REG_T0,
+      UInt32(FO.CtxDepth));
+    ExpectedWords[3] := Arm64LdrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(FO.CtxActs));
+    ExpectedWords[4] := Arm64MovzW(ARM64_REG_T0,
+      UInt16(FO.ActStride), 0);
+    ExpectedWords[6] := Arm64LdrX(ARM64_REG_CACHE0, ARM64_REG_CACHE0,
+      UInt32(FO.ActInstance));
+    ExpectedWords[10] := Arm64LdrX(ARM64_REG_T2, ARM64_REG_T1,
+      UInt32(GO.HeapFFree0));
+    ExpectedWords[13] := Arm64StrX(ARM64_REG_CACHE0, ARM64_REG_T1,
+      UInt32(GO.HeapFFree0));
+    ExpectedWords[15] := Arm64LdrX(ARM64_REG_T0, ARM64_REG_T1,
+      UInt32(GO.HeapMarkState));
+    ExpectedWords[18] := Arm64LdrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.BlockBase));
+    ExpectedWords[21] := Arm64LdrX(ARM64_REG_T0, ARM64_REG_T0,
+      UInt32(GO.BlockAllocated));
+    ExpectedWords[30] := Arm64LdrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.HeapBytesLive));
+    ExpectedWords[32] := Arm64StrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.HeapBytesLive));
+    ExpectedWords[33] := Arm64LdrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.HeapBytesAllocated));
+    ExpectedWords[35] := Arm64StrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.HeapBytesAllocated));
+    ExpectedWords[36] := Arm64LdrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.HeapObjectCount));
+    ExpectedWords[38] := Arm64StrX(ARM64_REG_T1, ARM64_REG_T0,
+      UInt32(GO.HeapObjectCount));
+    {$ENDIF}
     for I := 0 to High(FastPathWords) do
     begin
       Move(Words[I * 4], W, 4);
-      if (W <> FastPathWords[I]) and (I < High(FastPathWords)) then
-        Break;
+      Expect<UInt32>(W).ToBe(ExpectedWords[I]);
     end;
-    Expect<UInt32>(W).ToBe(FastPathWords[High(FastPathWords)]);
   finally
     Buf.Free;
   end;

--- a/source/units/Wasm.Jit.Arm64.pas
+++ b/source/units/Wasm.Jit.Arm64.pas
@@ -132,8 +132,7 @@ type
     Fields: array[0..15] of TWasmGcAllocField;
   end;
 
-  TArm64GcAllocArray = array[0..$FFFFFF] of TWasmGcAllocShape;
-  PArm64GcAllocArray = ^TArm64GcAllocArray;
+  PArm64GcAllocArray = ^TWasmGcAllocShape;
 
   { The store-relative offsets the fast path cannot probe itself (FHeap is
     private to Wasm.Runtime.Store); computed once per staged function from


### PR DESCRIPTION
## Summary

- replace the oversized Arm64 allocation-shape array type with the existing typed-pointer arithmetic model so FPC i386 can compile the JIT suites
- keep the Arm64 fast-path word test fully pinned on 64-bit hosts while deriving only host-layout immediates on 32-bit hosts, without skipping any assertion
- add the established `i386-win32` target to the PR matrix so this supported interpreter target is validated before merge
- update the handoff and workflow description for the two Windows targets

## Testing

- `lwpt install --frozen`
- `lwpt test source/units/Wasm.Jit.Arm64.Test.pas source/units/Wasm.Jit.Test.pas` — 2/2 passed
- `lwpt format --check` — 91/91 passed
- `lwpt agents --check`
- `lwpt build` — 3/3 passed
- `lwpt test` — 44/44 passed
- `npx --yes markdownlint-cli2 '**/*.md'` — 44 files, 0 issues
- `actionlint -ignore SC2005 .github/workflows/pr.yml`
- `git diff --check`

The new exact-head `i386-win32` PR job is the required platform-specific validation for compilation, the full test suite, CLI smoke checks, and interpreter conformance.

## Linked issues

Closes #24