### PR TITLE
perf(jit): accelerate fixed array access on x64

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,51 @@
 # Handoff
 
+Updated: 2026-08-24 (Wave 15 continuation; x64 fixed-array access accepted)
+
+## Wave 15 continuation — x64 fixed-array access ACCEPTED
+
+- Continued from exact green `origin/main@a1e565488507767a4db6bff19c73f60e645edb72`.
+  The accepted measured branch is `optimize/w15-x64-array` in worktree
+  `/Users/jstein/.t3/worktrees/wasmlight/w15-x64-array`; its local, unpushed
+  commit is `e160f6fc11ba548d57e5b16d2875e82bd17dd511`
+  (`perf(jit): emit fixed array access natively on x64`). Only
+  `Wasm.Jit.X64.pas`, `Wasm.Jit.X64.Test.pas`, and `Wasm.Jit.Test.pas` changed.
+- The x64 emitter now handles validated fixed scalar array get/set sites with
+  direct null, kind, and unsigned bounds checks followed by scaled addressing
+  and canonical scalar loads/stores. Ineligible shapes retain runtime dispatch;
+  no address is baked, and reference stores retain the current empty write-
+  barrier contract. Differential tests cover the compiled fresh-store null
+  path and byte-shape tests pin canonicalization plus null/kind/bounds order.
+- A checksum-pinned, host-locked B-C-C-B on emulated Linux/x86-64 measured the
+  self-checking 20-million-access target at 4467.419 -> 376.304 ms forward
+  (-91.58%) and 4492.286 -> 375.101 ms reverse (-91.65%), with no range
+  overlap. The representative GC workload improved about 29.7%. Across all 11
+  guard workloads, no candidate range was wholly slower and no apparent
+  regression exceeded 3%; the largest positive deltas were startup +1.85%,
+  memory-load +1.30%, and host-call +1.14%, all overlapping noise.
+- Final correctness passed independently on macOS/Arm64 and Linux/x86-64:
+  frozen install, format/agent/diff checks, clean dev and release builds, all
+  44 tests, and the exact 257-script pinned corpus on interpreter/JIT/AOT at
+  65,188 pass, 0 fail, 0 skip, 0 staged. Compiled counts were 0/8703/8703 on
+  Arm64 and 0/8704/8704 on x64. The evidence manifest contains 164 entries and
+  hashes to `fac4735b05c8fe96fe7014a08754b5281533703f81689157ca97eb19597bc894`.
+- Durable evidence is under
+  `/Users/jstein/.t3/evidence/wasmlight/w15-x64-array-a1e5654-container`.
+  The stable measurement replacement was an Ubuntu Noble linux/amd64 Docker
+  container under OrbStack, explicitly emulated rather than native x64. It was
+  stopped after the evidence lock and manifest were verified, and was retained
+  for reproducibility. The two diagnostic replacement VMs remain stopped; no
+  VM or container was deleted.
+- This x64-only win does not change the latest macOS/Arm64 Wasmtime comparison:
+  direct calls remain the largest measured gap at 2.73x, followed by memory-
+  store at 1.31x and SIMD at 1.28x. A later wave should re-profile calls from a
+  fresh main; do not retry either rejected Wave 15 direct-call mechanism
+  without new profile evidence.
+- Publication was requested through `/create-pr` on 2026-08-24. Next: open the
+  draft pull request, wait for exact-head CI, and mark it ready only when every
+  applicable check is green. No merge is authorized. Do not rerun paid
+  evaluation or claim native-x64 timing from this emulated environment.
+
 Updated: 2026-08-24 (PR #19-onwards retrospective follow-through)
 
 ## Issue #25 — harden optimization-wave gates

--- a/source/units/Wasm.Jit.Test.pas
+++ b/source/units/Wasm.Jit.Test.pas
@@ -3412,6 +3412,8 @@ begin
   FDiffThreshold := 0;
   Expect<Boolean>(DiffFresh(GcRefArrayModuleBytes, 'visible', []))
     .ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
+  Expect<Boolean>(DiffFresh(GcRefArrayModuleBytes, 'nullset', []))
+    .ToBe({$IFDEF WASM_JIT_BACKEND}True{$ELSE}False{$ENDIF});
   Expect<string>(TrapMessageOf(GcRefArrayModuleBytes, 'nullset', []))
     .ToBe('null array reference');
   Expect<Boolean>(DiffFresh(GcRefArrayModuleBytes, 'dirty', []))

--- a/source/units/Wasm.Jit.X64.Test.pas
+++ b/source/units/Wasm.Jit.X64.Test.pas
@@ -30,7 +30,9 @@ uses
   Wasm.Ir,
   Wasm.Jit.CodeBuffer,
   Wasm.Jit.X64,
-  Wasm.Runtime.Store;
+  Wasm.Runtime.Gc,
+  Wasm.Runtime.Store,
+  Wasm.Runtime.Traps;
 
 type
   TX64Tests = class(TTestSuite)
@@ -66,6 +68,7 @@ type
     procedure TestCallArityFence;
     procedure TestStaticCacheKeepsShiftResult;
     procedure TestGcFieldAccessBytes;
+    procedure TestGcArrayAccessBytes;
 
     procedure TestExecPlaceholder;
   end;
@@ -691,6 +694,96 @@ begin
   end;
 end;
 
+procedure TX64Tests.TestGcArrayAccessBytes;
+var
+  Buf: TWasmCodeBuffer;
+  Cache: TX64RegCache;
+  CanonPos, NullPos, KindPos, BoundsPos: Integer;
+
+  function FindSeq(const AExpected: array of Byte): Integer;
+  var
+    I, J: Integer;
+    Match: Boolean;
+  begin
+    Result := -1;
+    if Buf.Size < Length(AExpected) then
+      Exit;
+    for I := 0 to Buf.Size - Length(AExpected) do
+    begin
+      Match := True;
+      for J := 0 to High(AExpected) do
+        if Buf.ByteAt(I + J) <> AExpected[J] then
+        begin
+          Match := False;
+          Break;
+        end;
+      if Match then
+        Exit(I);
+    end;
+  end;
+
+  function HasSeq(const AExpected: array of Byte): Boolean;
+  begin
+    Result := FindSeq(AExpected) >= 0;
+  end;
+
+begin
+  { array.get_s i8: kind is checked before an unsigned bounds comparison;
+    the final address uses the canonicalized i32 index and MOVSX. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64InitRegCache(Cache);
+    X64EmitGcArrayAccess(Buf,
+      MakeIrInstr(iroArrayGetS, 2, 0, 1, 0), 7,
+      1 or 2 or 4 or (UInt64(1) shl 8) or
+        (UInt64(WASM_ARRAY_ELEMS_OFFSET) shl 16), Cache);
+    X64ResolvePatches(Buf);
+    CanonPos := FindSeq([$89, $C9]);
+    NullPos := FindSeq([$BF, Byte(Ord(wtkNullArrayReference)), $00, $00, $00,
+      $41, $FF, $17]);
+    KindPos := FindSeq([$8B, $10, $83, $E2, $1C, $83, $FA, $04]);
+    BoundsPos := FindSeq([$8B, $50, $08, $39, $D1, $0F, $82]);
+    Expect<Boolean>((CanonPos >= 0) and (CanonPos < NullPos) and
+      (NullPos < KindPos) and (KindPos < BoundsPos)).ToBe(True);
+    Expect<Boolean>(HasSeq([$48, $8D, $44, $08, $10,
+      $0F, $BE, $10])).ToBe(True);
+    Expect<Boolean>(HasSeq([$41, $FF, $57,
+      Byte(Ord(aohRtDispatch) * 8)])).ToBe(True);
+  finally
+    Buf.Free;
+  end;
+
+  { array.get_u i16 zero-extends from a scale-two element address. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64InitRegCache(Cache);
+    X64EmitGcArrayAccess(Buf,
+      MakeIrInstr(iroArrayGetU, 2, 0, 1, 0), 8,
+      1 or 4 or (UInt64(2) shl 8) or
+        (UInt64(WASM_ARRAY_ELEMS_OFFSET) shl 16), Cache);
+    X64ResolvePatches(Buf);
+    Expect<Boolean>(HasSeq([$48, $8D, $44, $48, $10,
+      $0F, $B7, $10])).ToBe(True);
+  finally
+    Buf.Free;
+  end;
+
+  { array.set i8 stores only the source's low byte. }
+  Buf := TWasmCodeBuffer.Create;
+  try
+    X64InitRegCache(Cache);
+    X64EmitGcArrayAccess(Buf,
+      MakeIrInstr(iroArraySet, 0, 1, 2, 0), 9,
+      1 or 4 or (UInt64(1) shl 8) or
+        (UInt64(WASM_ARRAY_ELEMS_OFFSET) shl 16), Cache);
+    X64ResolvePatches(Buf);
+    Expect<Boolean>(HasSeq([$48, $8D, $44, $08, $10])).ToBe(True);
+    Expect<Boolean>(HasSeq([$88, $10])).ToBe(True);
+  finally
+    Buf.Free;
+  end;
+end;
+
 procedure TX64Tests.TestSlotOffset;
 begin
   Expect<UInt32>(X64SlotByteOffset(0)).ToBe(0);
@@ -788,6 +881,8 @@ begin
     TestStaticCacheKeepsShiftResult);
   Test('numeric GC fields use baked native x64 loads and stores',
     TestGcFieldAccessBytes);
+  Test('fixed scalar arrays use native x64 loads and stores',
+    TestGcArrayAccessBytes);
   Test('executable proof is gated to a real x86-64 host', TestExecPlaceholder);
 end;
 

--- a/source/units/Wasm.Jit.X64.pas
+++ b/source/units/Wasm.Jit.X64.pas
@@ -397,6 +397,12 @@ function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
 procedure X64EmitGcFieldAccess(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AShape: UInt64;
   var ACache: TX64RegCache);
+{ Fixed-type scalar array access. A kind mismatch takes the unchanged helper
+  route so the runtime's internal invariant remains authoritative; null and
+  bounds traps are emitted in their original order on the native path. }
+procedure X64EmitGcArrayAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AInsIndex: UInt32; const AShape: UInt64;
+  var ACache: TX64RegCache);
 procedure X64EmitCompareBranchCached(const ABuf: TWasmCodeBuffer;
   const ACompare, ABranch: TWasmIrInstr; var ACache: TX64RegCache);
 function X64CanEmitInstr(const AIns: TWasmIrInstr;
@@ -428,6 +434,10 @@ uses
 procedure X64EmitScalarMemory(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAddr64,
   AUsePinnedMemory: Boolean); forward;
+procedure X64EmitAluRegImm8(const ABuf: TWasmCodeBuffer;
+  const ASubop: Byte; const AWide: Boolean; const AReg, AImm: Byte); forward;
+procedure X64EmitLeaIndexed(const ABuf: TWasmCodeBuffer;
+  const ADest, ABase, AIndex, AScale: Byte; const ADisp: Int32); forward;
 procedure X64EmitLoadScalar(const ABuf: TWasmCodeBuffer;
   const ADest, ABase: Byte; const ASize: UInt32; const ASigned,
   AResult64: Boolean); forward;
@@ -577,6 +587,104 @@ begin
   end;
 end;
 
+procedure X64EmitGcArrayAccess(const ABuf: TWasmCodeBuffer;
+  const AIns: TWasmIrInstr; const AInsIndex: UInt32; const AShape: UInt64;
+  var ACache: TX64RegCache);
+var
+  ObjSlot, IndexSlot: UInt32;
+  Width, Scale: Byte;
+  Signed: Boolean;
+  NonNull, KindFallback, InBounds, Done: TWasmJitLabel;
+begin
+  Width := Byte((AShape shr 8) and $FF);
+  Signed := (AShape and 2) <> 0;
+  case Width of
+    1: Scale := 0;
+    2: Scale := 1;
+    4: Scale := 2;
+  else
+    Scale := 3;
+  end;
+  if AIns.Op = iroArraySet then
+  begin
+    ObjSlot := AIns.Dest;
+    IndexSlot := AIns.A;
+  end
+  else
+  begin
+    ObjSlot := AIns.A;
+    IndexSlot := AIns.B;
+  end;
+
+  X64CachedLoad(ABuf, ACache, X64_RAX, ObjSlot);
+  X64CachedLoad(ABuf, ACache, X64_RCX, IndexSlot);
+  { The index is an i32. Canonicalize it before 64-bit address generation so
+    stale high slot bits cannot turn an in-bounds unsigned index into a wild
+    host address. }
+  X64EmitAluRegReg(ABuf, $89, False, X64_RCX, X64_RCX);
+  NonNull := ABuf.NewLabel;
+  KindFallback := ABuf.NewLabel;
+  InBounds := ABuf.NewLabel;
+  Done := ABuf.NewLabel;
+
+  X64EmitAluRegReg(ABuf, $85, True, X64_RAX, X64_RAX);
+  X64EmitJccTo(ABuf, X64_CC_NE, UInt32(NonNull));
+  X64EmitMovRegImm32(ABuf, X64_ARG0,
+    UInt32(Ord(wtkNullArrayReference)));
+  X64EmitCallHelper(ABuf, aohTrapKind);
+  ABuf.BindLabel(NonNull);
+
+  { Preserve ResolveElement's null -> layout/kind -> bounds order. The kind
+    mismatch is validator-unreachable, so the cold helper call exists only to
+    retain its exact EWasmInternal invariant rather than inventing a backend
+    error path. Header kind bits are masked in place; no runtime address is
+    baked into the emitted code. }
+  X64EmitLoadMem32(ABuf, X64_RDX, X64_RAX, 0);
+  X64EmitAluRegImm8(ABuf, 4, False, X64_RDX,
+    Byte(WASM_OBJ_KIND_MASK shl WASM_OBJ_KIND_SHIFT));
+  X64EmitAluRegImm8(ABuf, 7, False, X64_RDX,
+    Byte(Ord(wokArray) shl WASM_OBJ_KIND_SHIFT));
+  X64EmitJccTo(ABuf, X64_CC_NE, UInt32(KindFallback));
+
+  X64EmitLoadMem32(ABuf, X64_RDX, X64_RAX,
+    WASM_ARRAY_LENGTH_OFFSET);
+  X64EmitAluRegReg(ABuf, $39, False, X64_RCX, X64_RDX);
+  X64EmitJccTo(ABuf, X64_CC_B, UInt32(InBounds));
+  X64EmitMovRegImm32(ABuf, X64_ARG0,
+    UInt32(Ord(wtkArrayOutOfBounds)));
+  X64EmitCallHelper(ABuf, aohTrapKind);
+  ABuf.BindLabel(InBounds);
+  X64EmitLeaIndexed(ABuf, X64_RAX, X64_RAX, X64_RCX, Scale,
+    WASM_ARRAY_ELEMS_OFFSET);
+
+  if AIns.Op = iroArraySet then
+  begin
+    X64CachedLoad(ABuf, ACache, X64_RDX, AIns.B);
+    X64EmitStoreScalar(ABuf, X64_RDX, X64_RAX, Width);
+    { The v1 barrier is deliberately empty and a store cannot collect, so the
+      direct reference write has the same visibility semantics as ArraySet.
+      A non-empty future barrier must make reference shapes decline here or
+      gain a dedicated PIC helper before it changes collector policy. }
+  end
+  else
+  begin
+    X64EmitLoadScalar(ABuf, X64_RDX, X64_RAX, Width, Signed, Width = 8);
+    X64CachedStore(ABuf, ACache, X64_RDX, AIns.Dest);
+  end;
+  X64EmitJmpTo(ABuf, UInt32(Done));
+
+  ABuf.BindLabel(KindFallback);
+  { ResolveElement raises before consulting index/value on this path. Publish
+    the already-loaded object so X64RtDispatch observes the exact ref even if
+    its source slot currently lives only in the dynamic cache. }
+  X64EmitStoreSlot64(ABuf, X64_RAX, ObjSlot);
+  X64EmitMovRegReg(ABuf, X64_ARG0, X64_REG_STORE);
+  X64EmitMovRegReg(ABuf, X64_ARG1, X64_REG_REGFILE);
+  X64EmitIrInsPtr(ABuf, X64_ARG2, AInsIndex);
+  X64EmitCallHelper(ABuf, aohRtDispatch);
+  ABuf.BindLabel(Done);
+end;
+
 function X64EmitOpCached(const ABuf: TWasmCodeBuffer;
   const AIns: TWasmIrInstr; const AAux: TWasmIrAuxU32;
   const AInsIndex: UInt32; const AAddr64, AUsePinnedMemory,
@@ -595,10 +703,13 @@ begin
     Exit;
   end;
   if (AGcShapes <> nil) and
-    ((AGcShapes[AInsIndex] and 1) <> 0) and
-    ((AGcShapes[AInsIndex] and 4) = 0) then
+    ((AGcShapes[AInsIndex] and 1) <> 0) then
   begin
-    X64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
+    if (AGcShapes[AInsIndex] and 4) <> 0 then
+      X64EmitGcArrayAccess(ABuf, AIns, AInsIndex,
+        AGcShapes[AInsIndex], ACache)
+    else
+      X64EmitGcFieldAccess(ABuf, AIns, AGcShapes[AInsIndex], ACache);
     Exit;
   end;
   case AIns.Op of
@@ -1932,6 +2043,42 @@ begin
   if NeedSib then
     { scale=0, index=100 (none), base=BaseLow. }
     ABuf.EmitByte((4 shl 3) or BaseLow);
+  if ModB = 1 then
+    ABuf.EmitByte(Byte(ADisp))
+  else if ModB = 2 then
+    ABuf.EmitU32(UInt32(ADisp));
+end;
+
+procedure X64EmitAluRegImm8(const ABuf: TWasmCodeBuffer;
+  const ASubop: Byte; const AWide: Boolean; const AReg, AImm: Byte);
+begin
+  { Group-1 immediate ALU: 83 /subop ib. The immediate is sign-extended by
+    x86-64; callers here use only non-negative values below 128. }
+  X64EmitRex(ABuf, Ord(AWide), 0, 0, AReg shr 3);
+  ABuf.EmitByte($83);
+  EmitModRMReg(ABuf, ASubop, AReg);
+  ABuf.EmitByte(AImm);
+end;
+
+procedure X64EmitLeaIndexed(const ABuf: TWasmCodeBuffer;
+  const ADest, ABase, AIndex, AScale: Byte; const ADisp: Int32);
+var
+  BaseLow, ModB: Byte;
+begin
+  { LEA r64,[base + index*(1 shl scale) + disp] = 8D /r with a SIB byte.
+    The array path uses rcx as the index, never rsp's reserved no-index code. }
+  BaseLow := ABase and 7;
+  if (ADisp = 0) and (BaseLow <> 5) then
+    ModB := 0
+  else if (ADisp >= -128) and (ADisp <= 127) then
+    ModB := 1
+  else
+    ModB := 2;
+  X64EmitRex(ABuf, 1, ADest shr 3, AIndex shr 3, ABase shr 3);
+  ABuf.EmitByte($8D);
+  ABuf.EmitByte((ModB shl 6) or ((ADest and 7) shl 3) or 4);
+  ABuf.EmitByte(((AScale and 3) shl 6) or
+    ((AIndex and 7) shl 3) or BaseLow);
   if ModB = 1 then
     ABuf.EmitByte(Byte(ADisp))
   else if ModB = 2 then


### PR DESCRIPTION
## Summary

- emit validated fixed scalar array get/set operations directly in the x64 JIT and AOT path
- preserve null, kind, and unsigned bounds trap ordering while retaining runtime dispatch for ineligible shapes
- add differential behavior coverage and byte-emission assertions for canonicalization and trap order

## Performance

A checksum-pinned, host-locked B-C-C-B schedule over 20 million self-checking fixed-array accesses reduced median runtime from 4467.419 ms to 376.304 ms forward (-91.58%) and from 4492.286 ms to 375.101 ms in reverse order (-91.65%), with no range overlap. The representative GC workload improved by about 29.7%.

Across all 11 guard workloads, no candidate range was wholly slower and no apparent regression exceeded 3%. Measurements ran on Ubuntu Noble linux/amd64 emulated through OrbStack on Apple Arm hardware; they are not native-x64 timing claims.

## Testing

- `lwpt install --frozen`
- `lwpt format --check` (91 files)
- `lwpt agents --check`
- `lwpt build` and `lwpt build --mode release` (3/3 each)
- `lwpt test` (44/44)
- `npx markdownlint-cli2 "**/*.md"` (44 files, 0 issues)
- macOS/Arm64 and Linux/x86-64 pinned-core interpreter, JIT, and AOT runs: 257 files, 65,188 pass, 0 fail, 0 skip, 0 staged on every tier
- retained evidence manifest: 164/164 files verified, SHA-256 `fac4735b05c8fe96fe7014a08754b5281533703f81689157ca97eb19597bc894`

## Linked issues

None.