### PR TITLE
docs: publish native compiler roadmap

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,5 +1,186 @@
 # Handoff
 
+Updated: 2026-08-24 (roadmap and GitHub records created)
+
+## Proposed 0.2.0 native compiler and connectors
+
+- APPROVED on 2026-08-24: the complete version plan is `0.2.0` strict native
+  compiler/connectors/cross-compilation/Homebrew; `0.3.0` Win64; `0.4.0`
+  i386 Windows; `0.5.0` portable C/Nim/C#/Rust/Go/Python embedding SDKs;
+  `0.6.0` independently judged non-network WASI Preview 1; and `0.7.0`
+  operational observability. The approved 62 bounded issues were created
+  through the project-local `create-issue` workflow.
+- `ROADMAP-260824.md` records the approved evidence, architecture, dependency
+  shape, issue catalog, and canonical GitHub links. Six milestones were
+  created without due dates: `0.2.0` #29–#46 (18), `0.3.0` #47–#53 (7),
+  `0.4.0` #54–#61 (8), `0.5.0` #62–#77 (16), `0.6.0` #78–#85 (8), and
+  `0.7.0` #86–#90 (5). A live API audit found no missing milestone
+  assignments, `enhancement` labels, or required creator-attribution notes.
+  A transient GitHub 504 during the first batch was recovered by rereading
+  live state and resuming with exact-title duplicate checks; no duplicate was
+  created. No release, commit, or pull request was created.
+
+- Refreshed this worktree by fast-forwarding the clean detached head to exact
+  `origin/main@0d0c8ffd79067bae85b9d8d927cfab7c9b558753` before rechecking the
+  design against current source.
+- The next release is `0.2.0`, not `0.1.1`. The accepted compiler direction is
+  `wasmlight compile`: it produces a native executable by compiling every Wasm
+  function ahead of time. Compilation fails if any function cannot be
+  compiled; the generated executable contains neither the interpreter nor the
+  JIT compiler.
+- A connector is declarative C-ABI binding data, not Pascal or C source. It
+  maps named Wasm imports to explicitly approved symbols in dynamic native
+  libraries and is validated and embedded at compile time. TinyCC and
+  per-connector source compilation are not part of the direction.
+- Connector libraries are `.dylib`, `.so`, or `.dll` deployment dependencies.
+  A library written in Pascal is eligible when it exports a stable `cdecl` C
+  ABI. Statically linking arbitrary native objects or providing custom adapter
+  logic belongs to a Pascal embedder using `Wasm.Engine`, not to
+  `wasmlight compile`.
+- The existing deny-by-default `TWasmLinker` / `TWasmHostFunc` seam is the
+  source-level integration point. The GocciaScript comparison establishes the
+  intended mechanism: declarative signatures become ABI placement plans that
+  call through precompiled Pascal/assembly gates; no source compiler or
+  `libffi` is required.
+- Created issues cover connector declaration and import validation, the C-ABI
+  plan/call engine, guest-memory lifting/lowering and opaque handles,
+  dynamic-library capability and link errors, embedded connector plans, and
+  direct embedding documentation/examples.
+- Connector memory semantics are explicit: `copy-in`, `copy-out`, and `inout`
+  transfers; plus a scoped zero-copy borrow when performance requires it. A
+  borrow is bounds-checked through the existing memory chokepoint, lasts only
+  for one synchronous native call, and forbids callback/re-entry or retention.
+  Raw native pointers never enter the guest; persistent native resources cross
+  the boundary as validated opaque handles.
+- The connector language uses a constrained C# P/Invoke shape chosen for
+  regularity and AI-agent familiarity. A static class marked `[Connector]`
+  contains structs, enums, delegates, and `extern` methods. `[DllImport]`
+  selects the native library and `EntryPoint` aliases the guest-visible method
+  name to a different native symbol. Braces and semicolons follow ordinary C#
+  syntax consistently.
+- This is not C# and invokes no C# compiler. The Pascal implementation accepts
+  only connector declarations and a fixed attribute/type vocabulary; method
+  bodies, properties, inheritance, arbitrary generics, expressions, control
+  flow, and allocation are outside the language. It lowers declarations to
+  ABI plans plus ahead-of-time native call and callback thunks.
+- The earlier proposed one-way connector restriction was rejected: callbacks
+  are first-class delegate declarations. Same-thread callbacks can use the
+  engine's existing nested host-to-guest invocation support; foreign-thread
+  delivery remains a separate design boundary under ADR-0008.
+- `EntryPoint` performs name aliasing only. Guest and native signatures must be
+  compatible after fixed, familiar P/Invoke-style marshalling attributes such
+  as `[MarshalAs]`, `[In]`, and `[Out]`. Argument-reordering expressions, call
+  composition, hidden state, and an adapter expression language are excluded;
+  those needs use direct embedding.
+- A callback is direct and same-thread by default. A delegate marked
+  `[Queued]` may be invoked from a foreign thread: its arguments are copied
+  into connector-owned queue storage and the guest callback runs later on the
+  store thread. Queued callbacks must return `void` and cannot contain `ref`,
+  `out`, or borrowed memory. Foreign-thread callbacks requiring a synchronous
+  result or buffer mutation remain direct-embedding work under ADR-0008.
+- Delegate arguments are retained for the connector's lifetime by default;
+  identical delegate/function-reference pairs are deduplicated. `[Scoped]`
+  marks a callback that the native function guarantees cannot escape that one
+  call. Queued callbacks are necessarily retained, and connector teardown
+  invalidates every callback thunk before releasing the rooted guest function
+  references.
+- No guest failure unwinds through native C frames. A callback that encounters
+  `EWasmTrap`, `EWasmException`, or `EWasmExit` returns the native result type's
+  deterministic zero value and retains the exact failure. Once the native call
+  returns, the connector rethrows it unchanged on Pascal ground; when no
+  connector call is active, it surfaces at the next connector boundary. The
+  DSL has no configurable error expressions.
+- Connector selection is explicit and repeatable:
+  `wasmlight compile app.wasm --connector one.wlc --connector two.wlc -o app`.
+  `.wlc` is the Wasmlight Connector Language extension. There is no discovery,
+  registry lookup, network fetch, or import-triggered loading. Every guest
+  import resolves exactly once or compilation fails; unused declarations and
+  their libraries are stripped, and the resolved connector plan is embedded
+  immutably in the executable.
+- The first `wasmlight compile` release supports all-to-all cross-compilation
+  across the four 64-bit UNIX targets: AArch64 or x86-64 on macOS/Linux.
+  Unsupported targets fail explicitly; every successful output remains full
+  AOT and interpreter-free.
+- This is an initial delivery boundary, not the permanent target boundary.
+  Windows and 32-bit native compilation are required follow-ons. The current
+  governed matrix names them precisely as `x86_64-win64` and `i386-win32`.
+  Win64 can extend the x64 emitter but needs the Win64 ABI, executable/runtime
+  memory path, PE packaging, and Windows trap handling. i386 requires a new
+  machine-code backend and 32-bit ABI while retaining the explicit-bounds
+  memory strategy from ADR-0010.
+- The complete native-compile target matrix is AArch64 and x86-64 on macOS and
+  Linux, followed by x86-64 Windows and i386 Windows. Win64 precedes i386 in
+  the portability sequence because it can reuse the x64 emitter. ARM32 and
+  i386 Linux are explicitly out of scope: their device populations do not
+  justify the additional backends and validation matrix.
+- Current project docs still describe wasmlight as not being a compiler;
+  update the vision/roadmap only with the finalized, confirmation-gated plan
+  rather than documenting unshipped work as current behavior.
+- Fresh roadmap evidence at `origin/main@0d0c8ffd7906`: GitHub has one release
+  (`0.1.0`), no milestones, three issues (one open), and 24 merged pull
+  requests. The 90-day raw rate is 1.87 merges/week; the repository-age rate
+  is 13.9/week. Only two issue-linked deliveries exist, with 52-minute and
+  196-minute issue-created-to-merge times, so the plan supports dependency
+  ordering and bounded PR counts but not calendar dates.
+- `wasmlight compile` assembles its output from a prebuilt, interpreter-free
+  Pascal runtime shell for the host target, embedding the validated module,
+  complete native code, and immutable connector plan. This avoids requiring a
+  system compiler or linker while retaining startup validation and runtime
+  helpers. It does not emit object files or invoke a platform linker.
+- WASI configuration is compile-time configuration. `wasmlight compile`
+  embeds an immutable capability set in the executable; the executable has no
+  Wasmlight control arguments and every invocation argument belongs to the
+  guest. It never expands its permissions from ambient process state.
+- Compile-time `--dir GUEST=HOST` grants preserve absolute host paths exactly;
+  relative host paths resolve against the generated executable's directory at
+  run time so an application bundle can be relocated. `--env K=V` embeds the
+  literal value and is explicitly not a secret-delivery mechanism.
+- Connector library lookup is deterministic and application-local. A bare
+  `DllImport` name receives the platform filename convention and resolves
+  beside the executable; relative paths also resolve there, while absolute
+  paths remain literal. The runtime does not search the working directory,
+  `PATH`, `LD_LIBRARY_PATH`, or equivalent ambient paths.
+- Confirmation packet to present next: `0.2.0` delivers strict full-AOT native
+  executables, the runtime shell, immutable capabilities, and `.wlc`
+  connectors on 64-bit macOS/Linux; `0.3.0` extends that product to
+  x86_64-win64; `0.4.0` adds the new i386-win32 backend and product path. The
+  previously planned peer gaps are also part of the versioned plan:
+  `0.5.0` completes and governs the public embedding surface, `0.6.0` completes
+  non-network WASI Preview 1 behind `wasi-testsuite`, and `0.7.0` adds
+  operational observability. Component Model re-entry follows those milestones;
+  threads remain a separate demand-led programme.
+- Cross-compilation is requested as part of this programme. The source-level
+  prerequisite is to separate target code emission from host execution:
+  `Wasm.Jit` currently selects exactly one backend through host CPU/OS defines,
+  while `Wasm.Aot` derives architecture and ABI fingerprints from the live
+  host/store. Target selection and target ABI descriptors are foundational in
+  `0.2.0`: every shipped compiler host emits every released target through
+  `--target` (defaulting to the host). The four 64-bit Unix targets land in
+  `0.2.0`, Win64 joins the all-host target set in `0.3.0`, and i386 Windows in
+  `0.4.0`. Runtime shells for every released target ship with the compiler, so
+  no external compiler, linker, SDK, or interpreter is needed.
+- Cross-language embedding is a further confirmed gap. `Wasm.Engine` currently
+  exposes Pascal classes, managed strings/arrays, and Pascal exceptions, so it
+  is not itself a stable foreign-function boundary. Accepted `0.5.0` shape:
+  complete the Pascal embedding facade, place one versioned C ABI over it using
+  opaque handles, fixed-width values, explicit status/error objects, user-data
+  callbacks, and no exceptions across the boundary; ship `libwasmlight`, a C
+  header/examples, and first-party bindings for Nim, C#, Rust, Go, and Python.
+  Every binding consumes the same C ABI and language-neutral conformance kit
+  rather than adding runtime behavior or a language-specific engine.
+- Ecosystem registry publication is lower priority. Initial distribution uses
+  the existing `frostney/homebrew-tap`, whose current `lwpt` and GocciaScript
+  formulae install checksum-pinned macOS/Linux release archives. `0.2.0` adds
+  wasmlight platform archives and a tap formula for the compiler plus bundled
+  runtime shells; `0.5.0` extends the SDK archive/formula with
+  `libwasmlight`, the C header, and the C/Nim/C#/Rust/Go/Python bindings.
+  NuGet, crates.io, Nimble, Go-module, and PyPI publication remains a later
+  distribution increment rather than a milestone exit criterion.
+- Windows distribution uses checksum-verified `.zip` assets from the same
+  GitHub release. Homebrew is the primary macOS/Linux installation channel,
+  while the GitHub archives are the canonical cross-platform artifacts from
+  which the tap formula also installs.
+
 Updated: 2026-08-24 (Wave 15 continuation; x64 fixed-array access accepted)
 
 ## Wave 15 continuation — x64 fixed-array access ACCEPTED
@@ -2123,7 +2304,8 @@ cache-flush, predicate↔template completeness, layering. Found + FIXED:
    codegen; machine-register allocation (needs per-safepoint liveness
    maps). All behind the compile predicate / measured, never required for
    correctness (the interpreter is the tier of record).
-7. User decision standing: NO GitHub issues until the roadmap is done.
+7. The roadmap is approved and GitHub milestones/issues #29–#90 are created;
+   the next explicit execution action is `/milestone-rush 0.2.0`.
 8. Local hygiene: builds drop gitignored .o/.ppu into
    .lwpt/modules/testing/, breaking a LOCAL `lwpt install --frozen`
    (fresh CI clone unaffected). `rm` them if frozen complains.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,67 @@ A Pascal routine exposed to a module as an import. The only channel
 through which a guest can affect anything outside its own linear memory.
 _Avoid_: native function, callback, external, syscall
 
+**Connector**:
+A declarative binding from a module import to a function exported through a
+native library's C ABI. Its guest-visible name may alias a different native
+entry point; custom host logic belongs in an embedder.
+_Avoid_: adapter, wrapper, plugin, native module
+
+**Connector language**:
+The declaration-only language in which connectors describe data shapes,
+external functions, aliases, and callbacks. It resembles C# P/Invoke but has
+no general-purpose behaviour.
+_Avoid_: C#, C# subset, scripting language, configuration file
+
+**Connector plan**:
+The immutable set of connector bindings selected and resolved for one compiled
+executable. It contains only bindings required by that executable's imports.
+_Avoid_: connector manifest, registry, dependency graph
+
+**Runtime shell**:
+The prebuilt, interpreter-free Pascal executable template into which
+`wasmlight compile` embeds a validated module, complete native code, and its
+connector plan. It retains validation and runtime helpers but contains no
+interpreter or JIT compiler.
+_Avoid_: launcher, stub, wrapper executable, bundled runtime
+
+**Compiled capability set**:
+The immutable WASI permissions and values embedded by `wasmlight compile` in a
+native executable. The executable cannot expand this set at run time, and its
+invocation arguments belong entirely to the guest.
+_Avoid_: runtime configuration, ambient permissions, launcher options
+
+**Entry point alias**:
+A connector method whose guest-visible name differs from its native symbol.
+The two signatures remain compatible after the method's declared marshalling.
+_Avoid_: adapter, wrapper, function mapping
+
+**Queued callback**:
+A native callback whose copied notification is delivered later on the store's
+owning thread. It has no synchronous result or borrowed-memory access.
+_Avoid_: asynchronous callback, background callback, cross-thread call
+
+**Retained callback**:
+A callback whose native entry remains valid for the connector's lifetime.
+Connector callbacks are retained unless their declaration marks them scoped.
+_Avoid_: persistent callback, global callback, owned callback
+
+**Deferred callback failure**:
+A guest failure held at a native callback boundary and surfaced unchanged once
+native execution returns. The native caller receives the result type's zero
+value while the failure is pending.
+_Avoid_: swallowed error, native exception, callback error code
+
+**Scoped borrow**:
+A bounds-checked view of guest memory granted to a connector only for one
+synchronous host call. It cannot be retained or used across guest re-entry.
+_Avoid_: raw pointer, memory pointer, shared buffer
+
+**Opaque handle**:
+A guest-visible reference that a connector resolves to a native resource
+without exposing its address or representation.
+_Avoid_: pointer, address, native reference
+
 **Capability**:
 An explicitly granted host permission — a preopened directory, a clock, an
 environment variable. Deny-by-default: a guest gets exactly what the
@@ -111,6 +172,18 @@ _Avoid_: client, sandbox, user code, the wasm
 **Embedder**:
 The Pascal program that owns a store and grants its capabilities.
 _Avoid_: host application, consumer, user (a user is a person)
+
+**Embedding ABI**:
+The versioned C calling-convention surface exported by `libwasmlight`. It is
+the sole foreign-language boundary over the Pascal embedding facade and uses
+opaque handles, fixed-width values, explicit errors, and user-data callbacks.
+_Avoid_: C API, foreign runtime, language runtime
+
+**Language binding**:
+A thin, idiomatic package that exposes the embedding ABI to one language
+without reimplementing runtime behavior. First-party bindings share one
+language-neutral conformance kit.
+_Avoid_: runtime port, alternate engine, connector
 
 **Canonical ABI**:
 The Component Model's rules for lowering component types onto core

--- a/ROADMAP-260824.md
+++ b/ROADMAP-260824.md
@@ -1,0 +1,329 @@
+# Roadmap review — 2026-08-24
+
+## Decision summary
+
+The approved roadmap makes native application compilation the next product
+spine. `wasmlight compile` produces a complete native executable: every guest
+function is compiled ahead of time or compilation fails, and the output
+contains neither the interpreter nor the JIT compiler.
+
+The programme runs from `0.2.0` through `0.7.0`:
+
+1. strict native compilation, connectors, cross-compilation, and Homebrew;
+2. Win64 native compilation;
+3. i386 Windows native compilation;
+4. portable C, Nim, C#, Rust, Go, and Python embedding SDKs;
+5. independently judged non-network WASI Preview 1; and
+6. operational observability.
+
+This plan was explicitly approved on 2026-08-24. It replaces the post-`0.1.0`
+sequence in the 2026-08-15 review; it does not change the historical A–J record
+in `docs/roadmap.md`.
+
+## Evidence snapshot
+
+- Source: `frostney/wasmlight@0d0c8ffd79067bae85b9d8d927cfab7c9b558753`,
+  exact fetched `origin/main` on 2026-08-24.
+- CI: exact-main run 32737294593 passed across the six governed targets.
+- Forge before roadmap record creation: one published release (`0.1.0`), no
+  milestones, three issues (one open), no open pull requests, and 24 merged
+  pull requests.
+- Throughput: 24 merges in the 90-day window, or 1.87/week over the full
+  window and 13.9/week over the repository's short active history.
+- Issue lead time: only two issue-linked deliveries exist, at 52 and 196
+  minutes from issue creation to merge. That sample is too small for dates.
+- Core conformance: the pinned 257-script corpus remains 65,188 pass, zero
+  fail, zero skip, and zero staged on every applicable tier.
+- Peer comparison: Wasmtime, Wasmer, WasmEdge, WAMR, wazero, and wasm3 remain
+  useful references for production embedding, AOT distribution, platform
+  breadth, host integration, resource governance, and observability. Presence
+  in peer source is not treated as proof of equivalent conformance.
+
+## Source-level classification
+
+Only Partial or Absent capabilities are scheduled.
+
+| Capability | State | Current source evidence | Treatment |
+| --- | --- | --- | --- |
+| Pinned Core 3 execution | Done | Interpreter/JIT/AOT corpus identity | Preserve as a release gate |
+| AOT artifact cache | Done | `Wasm.Aot` and `.waot` load guards | Preserve for runtime use |
+| Strict whole-module AOT | Partial | `AotCompileModuleIr` records declined functions | `0.2.0` |
+| Native executable output | Absent | CLI has `aot`, not `compile`; no shell/packager | `0.2.0` |
+| Cross-compilation | Absent | backend and ABI derive from host defines/layout | `0.2.0`–`0.4.0` |
+| Declarative native connectors | Absent | `TWasmLinker` accepts Pascal callbacks only | `0.2.0` |
+| Native callbacks | Partial foundation | nested host-to-guest invocation exists; no native thunks/lifetimes/queue | `0.2.0` |
+| Compiled Windows | Absent | executable code is gated to 64-bit UNIX | `0.3.0` |
+| Compiled i386 | Absent | no i386 emitter; i386 is interpreter-only | `0.4.0` |
+| Complete Pascal embedding | Partial | table/tag imports and composition are missing | `0.5.0` |
+| Foreign-language embedding | Absent | Pascal classes, managed values, and exceptions are not a C ABI | `0.5.0` |
+| Complete WASI Preview 1 | Partial | 23 functions ship; standard non-network long tail is absent | `0.6.0` |
+| External WASI oracle | Absent | `wasi-testsuite` is not integrated | `0.6.0` |
+| Operational observability | Partial | IR inspection exists; runtime stacks/maps/statistics do not | `0.7.0` |
+| Component Model/current WASI | Absent, deferred | ADR-0014 re-entry gate remains | After `0.7.0` |
+| Threads/shared memory | Absent, intentionally separate | conflicts with ADR-0008 | Demand-led programme |
+
+## Accepted architecture
+
+### Strict native executables
+
+- `wasmlight compile` validates once, compiles every guest function, and fails
+  with an actionable diagnostic if any function cannot be compiled.
+- The output is built from a precompiled, interpreter-free Pascal runtime
+  shell. It embeds the original module for startup validation, complete native
+  code, the connector plan, and the compiled capability set.
+- The executable retains validation, runtime helpers, memory protection,
+  traps, exceptions, epoch interruption, GC, WASI, and connector support. It
+  contains no interpreter or JIT compiler.
+- No compiler, linker, SDK, or network access is required at compile time or
+  when running the output.
+
+### Cross-compilation
+
+- `--target` defaults to the host target.
+- Every shipped compiler host emits every released target.
+- `0.2.0`: AArch64/x86-64 macOS and Linux.
+- `0.3.0`: adds x86-64 Windows.
+- `0.4.0`: adds i386 Windows.
+- ARM32 and i386 Linux are explicitly out of scope.
+- Target code emission, target ABI descriptors, and shell templates are
+  independent of the compiler host. CI checks host-independent structure and
+  executes each output on its actual target without a 36-cell execution grid.
+
+### Connectors
+
+- `.wlc` is a declaration-only language with a constrained C# P/Invoke shape:
+  `[Connector]` static classes, structs, enums, delegates, and `extern`
+  methods. It is not C# and invokes no C# compiler.
+- `[DllImport]` selects a dynamic library; `EntryPoint` aliases the native
+  symbol only. Signatures remain compatible after fixed marshalling attributes.
+- A bare library name receives the platform naming convention and resolves
+  beside the executable. Relative paths resolve there; absolute paths remain
+  literal. Ambient loader paths are not searched.
+- Memory uses copy-in, copy-out, inout, or a scoped synchronous borrow through
+  the memory chokepoint. Persistent resources use opaque handles.
+- Direct callbacks run on the store thread. Retained callbacks are the default;
+  `[Scoped]` prevents escape. `[Queued]` copies a void notification from a
+  foreign thread for later delivery on the store thread.
+- Guest failures never unwind through native C frames. The connector returns a
+  zero value, retains the exact failure, and rethrows it on Pascal ground.
+- Connector selection is explicit and repeatable through `--connector`.
+  Resolution is compile-time, unique, deny-by-default, stripped to used
+  declarations, and embedded immutably.
+
+### Compiled capabilities
+
+- WASI configuration belongs to `wasmlight compile`; generated programs expose
+  no Wasmlight runtime flags and pass every invocation argument to the guest.
+- Relative preopened host paths resolve from the executable directory;
+  absolute paths remain literal.
+- Environment values are embedded literally and are not a secret mechanism.
+
+### Portable embedding
+
+- The Pascal facade remains canonical.
+- `libwasmlight` exports one versioned C ABI with opaque handles, fixed-width
+  values, explicit status/error objects, user-data callbacks, and no Pascal
+  exception crossing the boundary.
+- C, Nim, C#, Rust, Go, and Python are first-party bindings over that ABI.
+  They share one language-neutral conformance kit and do not reimplement the
+  runtime.
+
+### Distribution
+
+- GitHub Releases publish checksum-pinned archives. Windows uses `.zip`
+  archives; macOS/Linux use the established tap-compatible archive pattern.
+- `frostney/homebrew-tap` is the initial macOS/Linux distribution channel.
+- `0.2.0` installs the compiler and bundled shells. `0.5.0` adds
+  `libwasmlight`, the C header, and all first-party bindings.
+- Nimble, NuGet, crates.io, Go-module, and PyPI publication is lower-priority
+  follow-up work, not a `0.5.0` exit criterion.
+
+## Milestones and potential issues
+
+All issues use the existing `enhancement` label unless an issue is exclusively
+documentation, in which case it also uses `documentation`. Exact issue bodies
+must retain the architecture above, cite current source, state tier/capability
+impact, and name focused plus universal verification.
+
+### `0.2.0` — Native compiler and connectors
+
+Size: 18 bounded issues. Longest pole: compiled exception handling and removal
+of every AOT decline route.
+
+1. Record the strict native compiler, runtime shell, and cross-target ADR.
+2. Separate target architecture and ABI descriptions from host execution.
+3. Add an all-or-fail whole-module AOT API with structured diagnostics.
+4. Compile exception handlers, `throw`, and `throw_ref` on Arm64 and x64.
+5. Eliminate structural Arm64/x64 AOT declines and late branch-range fallback.
+6. Build the interpreter-free runtime shell and startup validation path.
+7. Define and verify the embedded native-executable payload format.
+8. Package ELF runtime shells for AArch64 and x86-64 Linux.
+9. Package Mach-O runtime shells for AArch64 and x86-64 macOS.
+10. Add target-shell discovery and deterministic cross-target selection.
+11. Add `wasmlight compile`, `--target`, and explicit connector selection.
+12. Embed immutable WASI directories, environment, and guest argument policy.
+13. Implement the `.wlc` parser and declaration model.
+14. Resolve connector imports, entry-point aliases, and unused declarations.
+15. Generate 64-bit Unix C-ABI call plans and load application-local libraries.
+16. Implement connector copying, scoped borrowing, and opaque handles.
+17. Implement direct, scoped, retained, and queued callback thunks and failures.
+18. Add cross-target end-to-end gates, release archives, and Homebrew formula.
+
+Exit: every guest function is native or compilation fails; generated programs
+contain neither interpreter nor JIT; every 64-bit Unix compiler emits every
+64-bit Unix target; native execution preserves the pinned tally and error
+semantics.
+
+### `0.3.0` — Win64 native compilation
+
+Size: seven bounded issues. Longest pole: Windows trap/exception behavior over
+the Win64 ABI.
+
+ 1. Add Windows executable-memory allocation and protection.
+ 2. Add Windows trap attribution and invocation-trampoline unwinding.
+ 3. Implement the Win64 x64 ABI for compiled guest and helper calls.
+ 4. Prove strict whole-module AOT coverage on x86-64 Windows.
+ 5. Package and load PE32+ runtime-shell payloads.
+ 6. Implement Win64 DLL calls, callbacks, and queued delivery.
+ 7. Add Win64 cross-target gates, release ZIPs, and Homebrew shell bundles.
+
+Exit: every released compiler host emits a strict, interpreter-free
+`x86_64-win64` executable that passes target-native conformance and connector
+tests.
+
+### `0.4.0` — i386 Windows native compilation
+
+Size: eight bounded issues. Longest pole: the new i386 backend.
+
+ 1. Record the i386 backend and target ABI contract.
+ 2. Implement i386 control flow, frames, direct calls, and helper calls.
+ 3. Complete i386 native lowering over the register IR.
+ 4. Add i386 exception handling, epoch checks, and stack maps.
+ 5. Integrate ADR-0010 explicit-bounds memory and trap behavior.
+ 6. Package and load PE32 runtime-shell payloads.
+ 7. Implement i386 `cdecl` connector calls and callbacks.
+ 8. Add i386 cross-target gates, release ZIPs, and Homebrew shell bundles.
+
+Exit: every released compiler host emits a strict, interpreter-free
+`i386-win32` executable; i386 remains byte-identical to the tier of record and
+uses explicit bounds checks.
+
+### `0.5.0` — Portable embedding SDKs
+
+Size: 16 bounded issues. Longest pole: a stable ownership/error/callback model
+that is idiomatic across unmanaged and managed languages.
+
+ 1. Complete public table and tag definitions and export lookup.
+ 2. Add instance-to-instance composition through `TWasmLinker`.
+ 3. Add store resource policies for instances, memories, tables, and growth.
+ 4. Expose epoch interruption and per-function tier policy publicly.
+ 5. Pin embedding ownership, lifetime, and negative-path contracts.
+ 6. Record the versioned `libwasmlight` C ABI and compatibility policy.
+ 7. Export modules, stores, linkers, instances, functions, and calls as opaque handles.
+ 8. Export explicit error, value, memory, and host-callback operations.
+ 9. Build and package `libwasmlight`, `wasmlight.h`, and C examples.
+10. Ship and verify the first-party Nim binding.
+11. Ship and verify the first-party C# binding.
+12. Ship and verify the first-party Rust binding.
+13. Ship and verify the first-party Go binding.
+14. Ship and verify the first-party Python binding.
+15. Build the shared cross-language embedding conformance kit.
+16. Install the portable SDK and bindings through Homebrew and release archives.
+
+Exit: the six first-party language surfaces pass the same ownership, callback,
+memory, error, and conformance cases over one versioned C ABI on every
+applicable target.
+
+### `0.6.0` — Independently judged WASI Preview 1
+
+Size: eight bounded issues. Longest pole: identical filesystem containment on
+POSIX and Windows.
+
+ 1. Integrate `wasi-testsuite` as the external Preview 1 oracle.
+ 2. Implement positional I/O, descriptor tell, and renumbering.
+ 3. Implement allocation, synchronization, flags, rights, and timestamp updates.
+ 4. Implement path hard-link and readlink operations under preopens.
+ 5. Implement rename, symlink, and path timestamp operations under preopens.
+ 6. Implement `poll_oneoff` and remaining non-network process behavior.
+ 7. Decide and implement Preview 1 reactor handling.
+ 8. Add cross-platform containment, negative-path, documentation, and release gates.
+
+Sockets remain excluded. A later socket slice requires separately approved,
+pre-granted socket handles and retains deny-by-default capability semantics.
+
+### `0.7.0` — Operational observability
+
+Size: five bounded issues. Longest pole: one correct stack model across
+interpreted, compiled, guest, and host frames.
+
+ 1. Add module- and name-section-aware guest stack traces.
+ 2. Unify diagnostic stacks across interpreter, JIT, and AOT frames.
+ 3. Publish profiler maps for generated native code.
+ 4. Add structured per-store and per-instance runtime statistics.
+ 5. Investigate and gate DWARF, coredump, and debugger integration.
+
+Exit: embedders and operators can attribute guest failures and runtime cost
+without changing execution semantics or widening capabilities.
+
+## Dependency shape
+
+```mermaid
+flowchart LR
+  C["0.2.0: compiler + connectors + cross"] --> W64["0.3.0: Win64"]
+  W64 --> W32["0.4.0: i386 Windows"]
+  C --> SDK["0.5.0: portable embedding SDKs"]
+  W32 --> SDK
+  SDK --> WASI["0.6.0: complete WASI P1"]
+  SDK --> OBS["0.7.0: observability"]
+  WASI --> CM["Component Model/current WASI re-entry"]
+  OBS --> CM
+  TH["Threads decision"] -. "revisit ADR-0008" .-> FUT["Separate programme"]
+```
+
+Implementation discovery for `0.5.0` may begin after the shared `0.2.0`
+architecture settles, while platform ports continue. Releases retain numeric
+order so every public SDK target is already a shipped compiler/runtime target.
+
+## Timeline and release cadence
+
+The plan contains approximately 62 bounded issues. Applying the available
+rates gives an unusably broad spread: about 33 weeks at the raw 90-day rate and
+about 4.5 weeks at the repository-age burst rate. The two issue-linked lead
+times do not make either bound predictive. No dated Gantt or due dates are
+justified.
+
+Re-estimate after four issue-linked compiler pull requests merge. Until then:
+
+- sequence by dependencies and exit criteria;
+- cut one pre-1.0 minor per coherent capability theme;
+- use patch releases only for correctness, conformance, security, or
+  tier-identity fixes;
+- require exact-head full CI before release; and
+- keep benchmark deltas informational and same-runner.
+
+## Created GitHub records
+
+The approved plan was created on GitHub on 2026-08-24 without due dates. The
+issue ranges follow the numbered catalog above and every issue carries the
+`enhancement` label and the required creator-attribution note.
+
+| Milestone | Issues | Count |
+| --- | --- | ---: |
+| [`0.2.0`](https://github.com/frostney/wasmlight/milestone/1) | [#29](https://github.com/frostney/wasmlight/issues/29)–[#46](https://github.com/frostney/wasmlight/issues/46) | 18 |
+| [`0.3.0`](https://github.com/frostney/wasmlight/milestone/2) | [#47](https://github.com/frostney/wasmlight/issues/47)–[#53](https://github.com/frostney/wasmlight/issues/53) | 7 |
+| [`0.4.0`](https://github.com/frostney/wasmlight/milestone/3) | [#54](https://github.com/frostney/wasmlight/issues/54)–[#61](https://github.com/frostney/wasmlight/issues/61) | 8 |
+| [`0.5.0`](https://github.com/frostney/wasmlight/milestone/4) | [#62](https://github.com/frostney/wasmlight/issues/62)–[#77](https://github.com/frostney/wasmlight/issues/77) | 16 |
+| [`0.6.0`](https://github.com/frostney/wasmlight/milestone/5) | [#78](https://github.com/frostney/wasmlight/issues/78)–[#85](https://github.com/frostney/wasmlight/issues/85) | 8 |
+| [`0.7.0`](https://github.com/frostney/wasmlight/milestone/6) | [#86](https://github.com/frostney/wasmlight/issues/86)–[#90](https://github.com/frostney/wasmlight/issues/90) | 5 |
+
+Live verification found 62 issues, no missing milestone assignments, no
+missing `enhancement` labels, and no missing creator notes.
+
+## After `0.7.0`
+
+- Re-run the Component Model/current WASI review against fresh primary source.
+- Require a reproducible pin, independent-enough oracle, stable Canonical ABI,
+  and deny-by-default capability model before implementation.
+- Design async hosting once against that selected standard.
+- Keep threads separate because shared memory reverses ADR-0008.
+- Adopt post-Core-3 proposals only after an explicit target/pinning decision.


### PR DESCRIPTION
## Summary

- record the approved source-level runtime comparison and version plan from 0.2.0 through 0.7.0
- define the native compiler, connector, callback, and portable embedding vocabulary
- link the 62 implementation issues and six milestones created from the review
- keep every proposed capability explicitly documented as roadmap work rather than shipped behavior

## Testing

- `lwpt install --frozen`
- `lwpt format --check`
- `lwpt build`
- `lwpt test` (44 passed)
- `npx --yes markdownlint-cli2 "**/*.md"` (45 files, 0 issues)
- `git diff --check`

## Linked issues

Tracks the approved roadmap represented by #29 through #90. This documentation PR does not close any implementation issue.