### PR TITLE
docs: record the strict native compiler contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,7 +119,8 @@ _Avoid_: connector manifest, registry, dependency graph
 The prebuilt, interpreter-free Pascal executable template into which
 `wasmlight compile` embeds a validated module, complete native code, and its
 connector plan. It retains validation and runtime helpers but contains no
-interpreter or JIT compiler.
+interpreter or JIT compiler
+([ADR-0015](docs/adr/0015-strict-native-compiler-and-runtime-shell.md)).
 _Avoid_: launcher, stub, wrapper executable, bundled runtime
 
 **Compiled capability set**:

--- a/VISION.md
+++ b/VISION.md
@@ -56,6 +56,13 @@ Component Model — component decode and canonical ABI lowering — is
 deferred to post-v1, deferred rather than dropped
 ([ADR-0014](docs/adr/0014-the-component-model-is-deferred-to-post-v1.md)).
 
+The next product spine, not yet shipped, is native application
+compilation: `wasmlight compile` produces a complete native executable
+from a validated module
+([ADR-0015](docs/adr/0015-strict-native-compiler-and-runtime-shell.md)).
+That work is sequenced in [roadmap.md](docs/roadmap.md). Until it lands,
+the shipped CLI remains `inspect` / `validate` / `run` / `aot`.
+
 wasmlight is a member of the lwpt ecosystem: built, tested, formatted, and
 released through lwpt, and consumable by any lwpt project.
 
@@ -85,11 +92,14 @@ released through lwpt, and consumable by any lwpt project.
 
 ## What wasmlight is not
 
-- **Not a WebAssembly compiler.** wasmlight executes modules; producing
-  them is another tool's job. (The sibling project
+- **Not a compiler that produces WebAssembly modules.** Producing `.wasm`
+  is another tool's job. The sibling project
   [lakon](https://github.com/frostney/lakon) compiles Object Pascal *to*
   WebAssembly — a natural counterpart, but neither project depends on
-  the other.)
+  the other. Compiling a validated module *to* a native executable is
+  planned `0.2.0` work
+  ([ADR-0015](docs/adr/0015-strict-native-compiler-and-runtime-shell.md)),
+  not a shipped command.
 - **Not a browser embedding.** No JavaScript API, no DOM, no `WebAssembly`
   namespace shim. The host is a Pascal program.
 - **Not a general-purpose sandbox for native code.** The isolation
@@ -112,4 +122,6 @@ released through lwpt, and consumable by any lwpt project.
 - [Roadmap](docs/roadmap.md) — what is shipped and what is next
 - [Code style](docs/code-style.md) — including the hot-path RTL policy
 - [CONTEXT.md](CONTEXT.md) — canonical glossary
-- [docs/adr/](docs/adr/) — architectural decisions
+- [docs/adr/](docs/adr/) — architectural decisions, including the planned
+  native-compiler contract
+  ([ADR-0015](docs/adr/0015-strict-native-compiler-and-runtime-shell.md))

--- a/docs/adr/0015-strict-native-compiler-and-runtime-shell.md
+++ b/docs/adr/0015-strict-native-compiler-and-runtime-shell.md
@@ -1,0 +1,70 @@
+# Strict native compilation uses an interpreter-free runtime shell
+
+`wasmlight compile` is the next product spine: it validates a module once,
+compiles every guest function, and fails with a structured diagnostic if any
+function cannot be compiled. The output is a complete native executable
+assembled from a prebuilt, interpreter-free Pascal runtime shell. It embeds
+the original module for startup revalidation, the complete native code, the
+resolved connector plan, and an immutable compiled capability set. The
+executable retains validation, runtime helpers, memory protection, traps,
+exceptions, epoch interruption, GC, WASI, and connector support. It contains
+neither the interpreter nor the JIT compiler.
+
+This is a different artifact from the shipped `.waot` cache
+([ADR-0001](./0001-tiered-execution-seam.md)). A `.waot` file is a
+per-module performance cache: load always re-decodes and re-validates, and a
+declined function stays interpreted. A compiled executable has no such
+fallback. The cache path remains for `wasmlight run --aot`. The compile path
+is all-or-fail.
+
+Cross-compilation is part of the same decision. Target architecture, ABI
+descriptors, and shell templates are independent of the compiler host. Every
+shipped compiler emits every released target through `--target`, which
+defaults to the host. The first released target set is AArch64 and x86-64 on
+macOS and Linux. Win64 and i386 Windows follow as later releases. ARM32 and
+i386 Linux are out of scope. Executable-memory allocation and native
+execution stay host-gated; byte emission does not.
+
+Connectors are declaration-only `.wlc` bindings, not Pascal or C source and
+not a C# compiler. `[DllImport]` selects an application-local dynamic
+library; `EntryPoint` aliases a native symbol. Memory crosses the existing
+chokepoint as copy-in, copy-out, inout, or a scoped synchronous borrow.
+Persistent resources use opaque handles. Guest failures never unwind through
+native C frames: the connector returns a zero value, retains the exact
+failure, and rethrows it on Pascal ground. Selection is explicit
+(`--connector`), unique, deny-by-default, stripped to used declarations, and
+embedded immutably.
+
+WASI configuration belongs to compile time. Generated programs expose no
+Wasmlight runtime flags; every invocation argument belongs to the guest.
+Relative preopened host paths resolve from the executable directory;
+absolute paths remain literal. Environment values are embedded literally and
+are not a secret mechanism.
+
+Rejected: **linking through a host C compiler, Zig, or SDK**, which is the
+Wasmer `create-exe` shape and requires a toolchain the Pascal embedder does
+not have. **TinyCC, libffi, or per-connector source compilation**, which
+imports another compiler and a second ABI planner. **Keeping the interpreter
+in the generated executable as a decline fallback**, which makes
+"interpreter-free" untrue and hides incomplete AOT. **Searching ambient
+loader paths** for connector libraries, which widens host capability past
+the deny-by-default boundary. **Skipping startup revalidation because the
+artifact is local**, which would turn the payload into a trust boundary.
+**Choosing the target from host CPU/OS defines**, which prevents one
+compiler binary from emitting another supported target.
+
+Consequences:
+
+- Implementation issues cite this ADR for the compile contract, shell,
+  payload, target descriptors, connector plan, and compiled capability set
+  instead of redefining them.
+- Validation remains the single pre-tier specification gate. Generated
+  executables stay observationally identical to the interpreter on the
+  pinned Core 3 corpus.
+- The error hierarchy, memory chokepoint, store-thread rule
+  ([ADR-0008](./0008-a-store-is-confined-to-one-thread.md)), and
+  deny-by-default host boundary remain intact.
+- `VISION.md`'s "not a WebAssembly compiler" fence still means wasmlight
+  does not produce `.wasm` modules. Compiling a validated module to a native
+  executable is planned product work, recorded here and sequenced in
+  [roadmap.md](../roadmap.md), not shipped behaviour.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,9 +33,11 @@
   from a Pascal host or from `wasmlight run` (Track F). The JIT and AOT are
   a 64-bit-UNIX acceleration (two backends, aarch64 and x86-64); on Windows
   and 32-bit targets the runtime is interpreter-only and still fully
-  conformant. [roadmap.md](roadmap.md) is the honest picture of what
-  remains — broader optimizing-compiler work and cross-platform CI
-  validation, not any missing behaviour.
+  conformant.   [roadmap.md](roadmap.md) is the honest picture of what
+  remains: the planned native-compiler spine
+  ([ADR-0015](adr/0015-strict-native-compiler-and-runtime-shell.md)),
+  broader optimizing-compiler work, and later platform and host-surface
+  releases. Nothing in v1 Core 3 behaviour is staged.
 
 ## Layering
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,28 +88,40 @@
   CI has now passed all six configured targets; the four 64-bit UNIX legs
   proved interpreter/JIT/AOT tally identity and the Windows legs proved the
   interpreter.
-- **Next sequence:** release `0.1.0`, then complete and govern the embedding
-  surface (`0.2.0`), independently judge and finish non-network WASI Preview 1
-  (`0.3.0`), and add operational observability (`0.4.0`). The source-verified
-  comparison, accepted decisions, and sizing evidence are in the
-  [2026-08-15 roadmap review](../ROADMAP-260815.md).
-- **No dates.** Seven merged pull requests provide an initial delivery sample,
+- **`0.1.0` has shipped.** The next product spine is native application
+  compilation: `wasmlight compile` produces a complete native executable
+  ([ADR-0015](adr/0015-strict-native-compiler-and-runtime-shell.md)). That
+  command is planned, not shipped. Merged work after `0.1.0` — JIT/GC
+  performance, CI hardening, and documentation — folds into `0.2.0` rather
+  than a `0.1.1` patch.
+- **Next sequence:** `0.2.0` strict native compiler, connectors,
+  64-bit Unix cross-compilation, and Homebrew; `0.3.0` Win64 native
+  compilation; `0.4.0` i386 Windows native compilation; `0.5.0` portable C,
+  Nim, C#, Rust, Go, and Python embedding SDKs; `0.6.0` independently judged
+  non-network WASI Preview 1; `0.7.0` operational observability. The
+  source-verified comparison, accepted decisions, and issue catalog are in
+  the [2026-08-24 roadmap review](../ROADMAP-260824.md). External review
+  automation ([#23](https://github.com/frostney/wasmlight/issues/23)) is
+  skipped for `0.2.0`.
+- **No dates.** Twenty-five merged pull requests provide a delivery sample,
   but the observed rate varies too widely to support a calendar commitment.
   Releases remain ordered by dependency and exit criteria.
 
 ## Confidence
 
 The original A-J plan was anchored on counted specification surface because
-the repository had no pull-request delivery history. It now has seven merged
-pull requests, but still no issue-created-to-merge sample and no release
-cadence. The observed rates range from 0.54 pull requests per week over 90 days
-to 17.3 during the short active burst; PR-open-to-merge time omits most
-investigation and implementation. Those data support bounded sequencing, not
-dates. Re-anchor after four issue-linked roadmap pull requests have merged.
+the repository had no pull-request delivery history. It now has twenty-five
+merged pull requests and one published release, but only two issue-linked
+deliveries and no compiler-implementation sample. The observed rates range
+from 1.94 pull requests per week over 90 days to 14.8 during the twelve-day
+active span; PR-open-to-merge time omits most investigation and
+implementation. Those data support bounded sequencing, not dates. Re-anchor
+after four issue-linked `0.2.0` implementation pull requests have merged.
 
-The current throughput calculations, source-level peer comparison, and
-confidence limits are recorded in the
-[2026-08-15 roadmap review](../ROADMAP-260815.md).
+The current throughput calculations, source-level comparison, and confidence
+limits are recorded in the
+[2026-08-24 roadmap review](../ROADMAP-260824.md). The 2026-08-15 review
+remains the historical A-J close-out.
 
 Spec counts below come from `wasm-mcp` at pinned `spec/main`
 `d7b37e4170d8315f2f1283aed4e8076591a9a333`; testsuite counts from
@@ -671,24 +683,37 @@ Wasmtime-anchored rather than a neutral conformance bar.
 
 ## Post-v1 version plan
 
-- **`0.1.0`: pinned-Core-3 baseline.** Changelog-first release of the shipped
-  runtime; no new runtime behavior.
-- **`0.2.0`: complete and governable embedding.** Public table/tag coverage,
-  instance composition, resource policy, epoch configuration, and ordinary
-  JIT policy.
-- **`0.3.0`: independently judged WASI Preview 1.** Wire `wasi-testsuite`, then
-  complete the 19 missing non-network functions. Sockets remain a later,
-  separately approved capability slice over pre-granted handles.
-- **`0.4.0`: operational runtime.** Name-aware guest stacks, profiler maps,
-  and structured statistics. Async hosting remains deferred to the Component
-  Model re-entry so the runtime designs one suspension mechanism.
-- **After `0.4.0`: Components and current WASI.** Re-enter only after a fresh
-  ADR proves a reproducible target, independent enough oracle, stable Canonical
-  ABI, and deny-by-default capability model. Threads remain a separate,
-  demand-led programme because they reverse ADR-0008.
+- **`0.1.0`: pinned-Core-3 baseline — shipped.** Changelog-first release of
+  the shipped runtime.
+- **`0.2.0`: native compiler and connectors.** Strict all-or-fail
+  `wasmlight compile`, interpreter-free runtime shells, declarative `.wlc`
+  connectors, all-to-all 64-bit Unix cross-compilation, release archives,
+  and Homebrew. Issues [#29](https://github.com/frostney/wasmlight/issues/29)–[#46](https://github.com/frostney/wasmlight/issues/46).
+  The compile contract is [ADR-0015](adr/0015-strict-native-compiler-and-runtime-shell.md).
+- **`0.3.0`: Win64 native compilation.** Extend strict compilation,
+  connectors, and distribution to `x86_64-win64`. Issues
+  [#47](https://github.com/frostney/wasmlight/issues/47)–[#53](https://github.com/frostney/wasmlight/issues/53).
+- **`0.4.0`: i386 Windows native compilation.** Add the `i386-win32`
+  backend, connectors, and distribution. Issues
+  [#54](https://github.com/frostney/wasmlight/issues/54)–[#61](https://github.com/frostney/wasmlight/issues/61).
+- **`0.5.0`: portable embedding SDKs.** Complete the Pascal facade and ship
+  C, Nim, C#, Rust, Go, and Python bindings over `libwasmlight`. Issues
+  [#62](https://github.com/frostney/wasmlight/issues/62)–[#77](https://github.com/frostney/wasmlight/issues/77).
+- **`0.6.0`: independently judged WASI Preview 1.** Wire `wasi-testsuite`,
+  then complete the 19 missing non-network functions. Sockets remain a
+  later, separately approved capability slice over pre-granted handles.
+  Issues [#78](https://github.com/frostney/wasmlight/issues/78)–[#85](https://github.com/frostney/wasmlight/issues/85).
+- **`0.7.0`: operational runtime.** Name-aware guest stacks, profiler maps,
+  and structured statistics. Async hosting remains deferred to the
+  Component Model re-entry so the runtime designs one suspension mechanism.
+  Issues [#86](https://github.com/frostney/wasmlight/issues/86)–[#90](https://github.com/frostney/wasmlight/issues/90).
+- **After `0.7.0`: Components and current WASI.** Re-enter only after a
+  fresh ADR proves a reproducible target, independent enough oracle, stable
+  Canonical ABI, and deny-by-default capability model. Threads remain a
+  separate, demand-led programme because they reverse ADR-0008.
 
-The detailed source evidence, dependency graph, sizing, and accepted decisions
-are in the [2026-08-15 roadmap review](../ROADMAP-260815.md).
+The detailed source evidence, dependency graph, sizing, and accepted
+decisions are in the [2026-08-24 roadmap review](../ROADMAP-260824.md).
 
 ## Not planned
 


### PR DESCRIPTION
## Summary

- Record ADR-0015: strict all-or-fail `wasmlight compile`, interpreter-free runtime shell, target-independent emission, connectors, and compile-time capabilities.
- Replace the stale public `0.1.0` → embedding/WASI/observability sequence with the approved `0.2.0`–`0.7.0` native-compiler spine.
- Keep `wasmlight compile` documented as planned work, not shipped behaviour.

## Testing

- `npx --yes markdownlint-cli2 "**/*.md"` (46 files, 0 issues)
- `git diff --check`
- `lwpt agents --check`
- `lwpt install --frozen`
- `lwpt format --check` (91 files)
- `lwpt build` (3 built)
- `lwpt test` (44 passed)

## Linked issues

Closes #29

Made with [Cursor](https://cursor.com)