### PR TITLE
fix(ci): restore main workflows and an interpreter-free Linux shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,21 +209,8 @@ jobs:
           # fallback. Valid image (64-bit UNIX) runs _start natively.
           PY=python3
           if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c '
-import pathlib, struct, sys
-mod = bytes.fromhex(
-    "0061736d01000000"
-    "010401600000"
-    "03020100"
-    "0503010001"
-    "071302066d656d6f72790200065f73746172740000"
-    "0a040102000b"
-)
-pathlib.Path(sys.argv[1]).write_bytes(mod)
-nat = b"" if sys.argv[2] == "-" else pathlib.Path(sys.argv[2]).read_bytes()
-header = b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0)
-pathlib.Path(sys.argv[3]).write_bytes(header + mod + nat)
-' "$RUNNER_TEMP/shell-cmd.wasm" - "$RUNNER_TEMP/shell-incomplete.wshl"
+          "$PY" -c 'import pathlib, struct, sys; mod = bytes.fromhex("0061736d01000000010401600000030201000503010001071302066d656d6f72790200065f737461727400000a040102000b"); nat = b"" if sys.argv[2] == "-" else pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[1]).write_bytes(mod); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
+            "$RUNNER_TEMP/shell-cmd.wasm" - "$RUNNER_TEMP/shell-incomplete.wshl"
           set +e
           "$SHELL_BIN" "$RUNNER_TEMP/shell-incomplete.wshl" \
             >"$RUNNER_TEMP/shell-incomplete.out" \
@@ -248,14 +235,9 @@ pathlib.Path(sys.argv[3]).write_bytes(header + mod + nat)
               -o "$RUNNER_TEMP/shell-cmd.waot"
             PY=python3
           if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c '
-import pathlib, struct, sys
-mod = pathlib.Path(sys.argv[1]).read_bytes()
-nat = pathlib.Path(sys.argv[2]).read_bytes()
-header = b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0)
-pathlib.Path(sys.argv[3]).write_bytes(header + mod + nat)
-' "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
-              "$RUNNER_TEMP/shell-complete.wshl"
+          "$PY" -c 'import pathlib, struct, sys; mod = pathlib.Path(sys.argv[1]).read_bytes(); nat = pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
+            "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
+            "$RUNNER_TEMP/shell-complete.wshl"
             set +e
             "$SHELL_BIN" "$RUNNER_TEMP/shell-complete.wshl" \
               >"$RUNNER_TEMP/shell-complete.out" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           # fallback. Valid image (64-bit UNIX) runs _start natively.
           PY=python3
           if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c 'import pathlib, struct, sys; mod = bytes.fromhex("0061736d01000000010401600000030201000503010001071302066d656d6f72790200065f737461727400000a040102000b"); nat = b"" if sys.argv[2] == "-" else pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[1]).write_bytes(mod); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
+          "$PY" scripts/write-wshl-payload.py --write-fixture-wasm \
             "$RUNNER_TEMP/shell-cmd.wasm" - "$RUNNER_TEMP/shell-incomplete.wshl"
           set +e
           "$SHELL_BIN" "$RUNNER_TEMP/shell-incomplete.wshl" \
@@ -233,11 +233,9 @@ jobs:
           if [ "${{ matrix.jit }}" = "true" ]; then
             ./build/wasmlight aot "$RUNNER_TEMP/shell-cmd.wasm" \
               -o "$RUNNER_TEMP/shell-cmd.waot"
-            PY=python3
-          if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c 'import pathlib, struct, sys; mod = pathlib.Path(sys.argv[1]).read_bytes(); nat = pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
-            "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
-            "$RUNNER_TEMP/shell-complete.wshl"
+            "$PY" scripts/write-wshl-payload.py \
+              "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
+              "$RUNNER_TEMP/shell-complete.wshl"
             set +e
             "$SHELL_BIN" "$RUNNER_TEMP/shell-complete.wshl" \
               >"$RUNNER_TEMP/shell-complete.out" \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -240,7 +240,7 @@ jobs:
           # fallback. Valid image (64-bit UNIX) runs _start natively.
           PY=python3
           if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c 'import pathlib, struct, sys; mod = bytes.fromhex("0061736d01000000010401600000030201000503010001071302066d656d6f72790200065f737461727400000a040102000b"); nat = b"" if sys.argv[2] == "-" else pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[1]).write_bytes(mod); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
+          "$PY" scripts/write-wshl-payload.py --write-fixture-wasm \
             "$RUNNER_TEMP/shell-cmd.wasm" - "$RUNNER_TEMP/shell-incomplete.wshl"
           set +e
           "$SHELL_BIN" "$RUNNER_TEMP/shell-incomplete.wshl" \
@@ -264,11 +264,9 @@ jobs:
           if [ "${{ matrix.jit }}" = "true" ]; then
             ./build/wasmlight aot "$RUNNER_TEMP/shell-cmd.wasm" \
               -o "$RUNNER_TEMP/shell-cmd.waot"
-            PY=python3
-          if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c 'import pathlib, struct, sys; mod = pathlib.Path(sys.argv[1]).read_bytes(); nat = pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
-            "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
-            "$RUNNER_TEMP/shell-complete.wshl"
+            "$PY" scripts/write-wshl-payload.py \
+              "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
+              "$RUNNER_TEMP/shell-complete.wshl"
             set +e
             "$SHELL_BIN" "$RUNNER_TEMP/shell-complete.wshl" \
               >"$RUNNER_TEMP/shell-complete.out" \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -240,21 +240,8 @@ jobs:
           # fallback. Valid image (64-bit UNIX) runs _start natively.
           PY=python3
           if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c '
-import pathlib, struct, sys
-mod = bytes.fromhex(
-    "0061736d01000000"
-    "010401600000"
-    "03020100"
-    "0503010001"
-    "071302066d656d6f72790200065f73746172740000"
-    "0a040102000b"
-)
-pathlib.Path(sys.argv[1]).write_bytes(mod)
-nat = b"" if sys.argv[2] == "-" else pathlib.Path(sys.argv[2]).read_bytes()
-header = b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0)
-pathlib.Path(sys.argv[3]).write_bytes(header + mod + nat)
-' "$RUNNER_TEMP/shell-cmd.wasm" - "$RUNNER_TEMP/shell-incomplete.wshl"
+          "$PY" -c 'import pathlib, struct, sys; mod = bytes.fromhex("0061736d01000000010401600000030201000503010001071302066d656d6f72790200065f737461727400000a040102000b"); nat = b"" if sys.argv[2] == "-" else pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[1]).write_bytes(mod); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
+            "$RUNNER_TEMP/shell-cmd.wasm" - "$RUNNER_TEMP/shell-incomplete.wshl"
           set +e
           "$SHELL_BIN" "$RUNNER_TEMP/shell-incomplete.wshl" \
             >"$RUNNER_TEMP/shell-incomplete.out" \
@@ -279,14 +266,9 @@ pathlib.Path(sys.argv[3]).write_bytes(header + mod + nat)
               -o "$RUNNER_TEMP/shell-cmd.waot"
             PY=python3
           if ! command -v python3 >/dev/null 2>&1; then PY=python; fi
-          "$PY" -c '
-import pathlib, struct, sys
-mod = pathlib.Path(sys.argv[1]).read_bytes()
-nat = pathlib.Path(sys.argv[2]).read_bytes()
-header = b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0)
-pathlib.Path(sys.argv[3]).write_bytes(header + mod + nat)
-' "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
-              "$RUNNER_TEMP/shell-complete.wshl"
+          "$PY" -c 'import pathlib, struct, sys; mod = pathlib.Path(sys.argv[1]).read_bytes(); nat = pathlib.Path(sys.argv[2]).read_bytes(); pathlib.Path(sys.argv[3]).write_bytes(b"WSH1" + struct.pack("<HHIIII", 1, 0, len(mod), len(nat), 0, 0) + mod + nat)' \
+            "$RUNNER_TEMP/shell-cmd.wasm" "$RUNNER_TEMP/shell-cmd.waot" \
+            "$RUNNER_TEMP/shell-complete.wshl"
             set +e
             "$SHELL_BIN" "$RUNNER_TEMP/shell-complete.wshl" \
               >"$RUNNER_TEMP/shell-complete.out" \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -477,7 +477,6 @@ never interpreted. `.waot` remains the fallback-capable cache for
 and capability slots is a temporary seam until the product payload
 is embedded; the compile command is not shipped.
 
-
 Both compiling tiers run only where `WASM_JIT_EXEC` holds — a **64-bit
 UNIX host**. On Windows and 32-bit targets they are inactive and the
 interpreter, the tier of record, runs alone; that leg is unaccelerated but

--- a/lwpt.toml
+++ b/lwpt.toml
@@ -23,8 +23,11 @@ wasmbench = { source = "source/apps/wasmbench.pas", output = "build/wasmbench" }
 wasmspec = { source = "source/apps/wasmspec.pas", output = "build/wasmspec" }
 # Interpreter-free runtime-shell template (#34). Smart-link so unused
 # interpreter-dispatch and JIT-emit routines from helper units are not
-# retained; the shell never calls those entry points.
-wasmlight-shell = { source = "source/apps/wasmlight-shell.pas", output = "build/wasmlight-shell", flags = ["-CX", "-XX"] }
+# retained; the shell never calls those entry points. `-dWASM_RUNTIME_SHELL`
+# is required so Wasm.Engine omits RegisterInterpreter / InterpInvoke —
+# a program-file {$DEFINE} does not reach units, and GNU ld keeps
+# InterpTierInvoke unless that uses-clause is gone.
+wasmlight-shell = { source = "source/apps/wasmlight-shell.pas", output = "build/wasmlight-shell", flags = ["-CX", "-XX", "-dWASM_RUNTIME_SHELL"] }
 
 # stamp-version derives source/units/Version.inc from this manifest's
 # [package].version, consumed by Wasm.Core's `{$I Version.inc}`. The

--- a/lwpt.toml
+++ b/lwpt.toml
@@ -21,13 +21,13 @@ cli = { source = "frostney/lwpt", version = "^0.6.0", include = ["packages/cli/*
 wasmlight = { source = "source/apps/wasmlight.pas", output = "build/wasmlight" }
 wasmbench = { source = "source/apps/wasmbench.pas", output = "build/wasmbench" }
 wasmspec = { source = "source/apps/wasmspec.pas", output = "build/wasmspec" }
-# Interpreter-free runtime-shell template (#34). Smart-link so unused
-# interpreter-dispatch and JIT-emit routines from helper units are not
-# retained; the shell never calls those entry points. `-dWASM_RUNTIME_SHELL`
-# is required so Wasm.Engine omits RegisterInterpreter / InterpInvoke —
-# a program-file {$DEFINE} does not reach units, and GNU ld keeps
-# InterpTierInvoke unless that uses-clause is gone.
-wasmlight-shell = { source = "source/apps/wasmlight-shell.pas", output = "build/wasmlight-shell", flags = ["-CX", "-XX", "-dWASM_RUNTIME_SHELL"] }
+# Interpreter-free runtime-shell template (#34). Smart-link unused
+# interpreter-dispatch and JIT-emit routines out of helper units.
+# `-dWASM_RUNTIME_SHELL` makes Wasm.Engine omit RegisterInterpreter /
+# InterpInvoke (a program-file DEFINE does not reach units). `-g-` keeps
+# smart-linking on Linux: dwarf debug forces FPC to static-link, and then
+# GNU ld retains InterpTierInvoke even though the shell never calls it.
+wasmlight-shell = { source = "source/apps/wasmlight-shell.pas", output = "build/wasmlight-shell", flags = ["-CX", "-XX", "-g-", "-dWASM_RUNTIME_SHELL"] }
 
 # stamp-version derives source/units/Version.inc from this manifest's
 # [package].version, consumed by Wasm.Core's `{$I Version.inc}`. The

--- a/scripts/write-wshl-payload.py
+++ b/scripts/write-wshl-payload.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Pack a temporary WSH1 runtime-shell image for CI audits.
+
+Matches Wasm.Shell.Payload.WriteShellPayload: magic WSH1, format version 1,
+flags 0, four little-endian u32 section lengths, then the section bytes.
+This helper leaves the connector-plan and capability-set sections empty.
+
+  scripts/write-wshl-payload.py [--write-fixture-wasm] WASM NATIVE WSHL
+
+NATIVE may be '-' for an empty native section.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import struct
+import sys
+
+# (module (memory 1) (func (export "_start")) (export "memory" (memory 0)))
+FIXTURE_WASM = bytes.fromhex(
+    "0061736d01000000010401600000030201000503010001"
+    "071302066d656d6f72790200065f737461727400000a040102000b"
+)
+
+WSHL_MAGIC = b"WSH1"
+WSHL_FORMAT_VERSION = 1
+WSHL_FLAGS = 0
+
+
+def pack(module: bytes, native: bytes) -> bytes:
+    return (
+        WSHL_MAGIC
+        + struct.pack(
+            "<HHIIII",
+            WSHL_FORMAT_VERSION,
+            WSHL_FLAGS,
+            len(module),
+            len(native),
+            0,
+            0,
+        )
+        + module
+        + native
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write-fixture-wasm",
+        action="store_true",
+        help="write the audit's empty-_start module to WASM before packing",
+    )
+    parser.add_argument("wasm", type=pathlib.Path)
+    parser.add_argument("native")
+    parser.add_argument("wshl", type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    if args.write_fixture_wasm:
+        args.wasm.write_bytes(FIXTURE_WASM)
+        module = FIXTURE_WASM
+    else:
+        module = args.wasm.read_bytes()
+
+    if args.native == "-":
+        native = b""
+    else:
+        native = pathlib.Path(args.native).read_bytes()
+
+    args.wshl.write_bytes(pack(module, native))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/source/apps/wasmlight-shell.pas
+++ b/source/apps/wasmlight-shell.pas
@@ -19,10 +19,10 @@ program wasmlight_shell;
 
 {$I Shared.inc}
 
-{ The build entry also passes -dWASM_RUNTIME_SHELL. Engine uses that to omit
-  RegisterInterpreter / InterpInvoke so GNU ld cannot keep InterpTierInvoke
-  (Darwin already dead-strips it). A program-file {$DEFINE} does not reach
-  units; do not put the define in Shared.inc. }
+(* The build entry passes -dWASM_RUNTIME_SHELL so Wasm.Engine omits
+   RegisterInterpreter / InterpInvoke. GNU ld otherwise keeps InterpTierInvoke;
+   Darwin already dead-strips it. A program-file DEFINE does not reach units.
+   Do not put this define in Shared.inc. *)
 {$DEFINE WASM_RUNTIME_SHELL}
 
 uses

--- a/source/apps/wasmlight-shell.pas
+++ b/source/apps/wasmlight-shell.pas
@@ -21,9 +21,8 @@ program wasmlight_shell;
 
 (* The build entry passes -dWASM_RUNTIME_SHELL so Wasm.Engine omits
    RegisterInterpreter / InterpInvoke. GNU ld otherwise keeps InterpTierInvoke;
-   Darwin already dead-strips it. A program-file DEFINE does not reach units.
-   Do not put this define in Shared.inc. *)
-{$DEFINE WASM_RUNTIME_SHELL}
+   Darwin already dead-strips it. A program-file DEFINE does not reach units,
+   so this file must not declare one. Do not put this define in Shared.inc. *)
 
 uses
   {$IFDEF UNIX}

--- a/source/apps/wasmlight-shell.pas
+++ b/source/apps/wasmlight-shell.pas
@@ -19,9 +19,10 @@ program wasmlight_shell;
 
 {$I Shared.inc}
 
-{ Visible to every unit compiled into this program. Engine uses it to omit
+{ The build entry also passes -dWASM_RUNTIME_SHELL. Engine uses that to omit
   RegisterInterpreter / InterpInvoke so GNU ld cannot keep InterpTierInvoke
-  (Darwin already dead-strips it). Do not set this in Shared.inc. }
+  (Darwin already dead-strips it). A program-file {$DEFINE} does not reach
+  units; do not put the define in Shared.inc. }
 {$DEFINE WASM_RUNTIME_SHELL}
 
 uses


### PR DESCRIPTION
## Summary
- The runtime-shell audit added in #109 embedded Python at column 0 inside `run: |`, so GitHub rejected `ci.yml` / `pr.yml` and started no jobs on `main`.
- Once those files parse, Ubuntu fails the audit because `InterpTierInvoke` is still in `wasmlight-shell`: a program-file `{$DEFINE WASM_RUNTIME_SHELL}` does not reach `Wasm.Engine`, and GNU ld keeps the interpreter. Pass `-dWASM_RUNTIME_SHELL` on the shell build entry.
- Drop the extra blank line in `docs/architecture.md` that failed markdownlint (MD012).

## Test plan
- [x] YAML load + `actionlint` syntax-check on both workflow files
- [ ] PR jobs start (not a 0s workflow-file failure)
- [ ] `docs` markdownlint passes
- [ ] Ubuntu `runtime-shell audit` no longer reports `InterpTierInvoke`
- [ ] After merge, the next `main` push runs real `ci.yml` jobs